### PR TITLE
Add offline page saving

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -25,15 +25,11 @@ function generateFilePaths(url) {
 function screenshotExists(filepath) {
     return fs.existsSync(filepath);
 }
-function sitemapCacheDir(filepath) {
-
+function sitemapCacheDir() {
     const SITEMAP_CACHE_DIR = path.resolve(config.paths.baseDir, 'assets/sitemap-cache');
-
-    // Ensure the cache directory exists
     if (!fs.existsSync(SITEMAP_CACHE_DIR)) {
         fs.mkdirSync(SITEMAP_CACHE_DIR);
     }
-
     return SITEMAP_CACHE_DIR;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -15,6 +15,7 @@
             <input type="url" id="urlInput" value="https://funkpd.com/" placeholder="Enter URL...">
             <button type="submit">Capture Screenshot</button>
         </form>
+        <button id="savePageBtn" type="button">Save Page</button>
     </header>
     <main id="gallery">
         <section id="result" class="flex-row flex-gap">


### PR DESCRIPTION
## Summary
- add save page button in UI
- inline all assets and images for offline export
- expose savePage logic client-side
- clean up sitemap cache helper
- improve sitemap fetching
- validate URL in capture route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684056664e4c8325b7e07cd7bf16ce13