### PR TITLE
Add cookie option for auth capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+Public repo. Keep code and secrets safe.
+Prefer native modules. Avoid unnecessary packages or APIs.
+Stick to YAGNI, KISS and DRY principles.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
-## IDEAS
+# Screenshot Pro
+Simple site screenshot tool.
 
-### Check each page for word-count
+## Quick Start
+1. `npm install`
+2. `node index.js`
+
+Visit `http://localhost:3200` for the UI. POST `/capture` with `{url, cookie}` for API access.

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,6 +17,7 @@ const router = express.Router();
  */
 router.post("/capture", async (req, res) => {
         const url = req.body.url;
+        const cookie = req.body.cookie || '';
         if (!url) {
                 res.status(400).json({ error: "Missing field url; add to body." });
                 return;
@@ -27,7 +28,7 @@ router.post("/capture", async (req, res) => {
                 const results = [];
 
                 for (const siteUrl of sitemapUrls) {
-                        const imageData = await captureDesktopScreenshot(siteUrl);
+                        const imageData = await captureDesktopScreenshot(siteUrl, cookie);
                         clients.forEach((client) => {
                                 client.write(`data: ${JSON.stringify({ imageData })}\n\n`);
                         });

--- a/src/screenshot.js
+++ b/src/screenshot.js
@@ -50,7 +50,7 @@ async function cacheAssets(page) {
 }
 
 // Capture and save a screenshot using Puppeteer
-async function _takeScreenshot(url) {
+async function _takeScreenshot(url, cookie) {
     console.log("START: takeScreenshot");
     const { screenshotsDir, finalFilePath, relativePath } = generateFilePaths(url);
     console.log("FILE:" + finalFilePath);
@@ -70,6 +70,9 @@ async function _takeScreenshot(url) {
     console.log("launch:");
     const page = await browser.newPage();
     console.log("newPage:");
+    if (cookie) {
+        await page.setExtraHTTPHeaders({ Cookie: cookie });
+    }
 
     await cacheAssets(page);
 
@@ -103,9 +106,9 @@ async function _getImageDimensions(imagePath) {
 }
 
 // A higher-level function that captures, processes, and returns screenshot details
-async function captureDesktopScreenshot(url) {
+async function captureDesktopScreenshot(url, cookie) {
     console.log("START: captureDesktopScreenshot");
-    const { status, filepath, relativePath } = await _takeScreenshot(url);
+    const { status, filepath, relativePath } = await _takeScreenshot(url, cookie);
     console.log("GGG " );
     console.log("status " + status);
     console.log("filepath " + filepath);

--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,7 @@
         <h1>ScreenShot Pro</h1>
         <form id="capture-form">
             <input type="url" id="urlInput" value="https://funkpd.com/" placeholder="Enter URL...">
+            <input type="text" id="cookieInput" placeholder="Cookie string...">
             <button type="submit">Capture Screenshot</button>
         </form>
         <button id="savePageBtn" type="button">Save Page</button>

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", function() {
     const captureForm = document.getElementById("capture-form");
     const urlInput = document.getElementById("urlInput");
+    const cookieInput = document.getElementById("cookieInput");
     const gallery = document.getElementById("gallery");
     const result = document.getElementById("result");
     const templateImageWrap = document.querySelector(".image-wrap");
@@ -24,7 +25,7 @@ document.addEventListener("DOMContentLoaded", function() {
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ url })
+                body: JSON.stringify({ url, cookie: cookieInput.value })
             });
         } catch (error) {
             console.error("Failed to communicate with server:", error);


### PR DESCRIPTION
## Summary
- let users specify auth cookie for screenshot capture
- use the cookie in Puppeteer and API
- document minimal usage
- add AGENTS instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848eae0c8c08325863095a83acfa4a2