### PR TITLE
Add multi-viewport capture and UI toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+public/shots/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# screenshot-pro
+# Screenshot Pro
+
+Simple service to capture webpages in desktop, tablet and mobile viewports.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   node src/server.js
+   ```
+3. Open `http://localhost:3000` in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "screenshot-pro",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "puppeteer": "^24.10.1"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Screenshot Pro</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="controls">
+    <input id="url" type="text" placeholder="https://example.com">
+    <button id="capture">Capture</button>
+    <div id="viewports">
+      <button data-vp="d" class="vp-btn active">Desktop</button>
+      <button data-vp="t" class="vp-btn">Tablet</button>
+      <button data-vp="m" class="vp-btn">Mobile</button>
+    </div>
+  </div>
+  <div id="shots"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,48 @@
+let active = 'd';
+
+function refresh() {
+  fetch('/api/shots').then(r => r.json()).then(data => {
+    const container = document.getElementById('shots');
+    container.innerHTML = '';
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'card';
+      const title = document.createElement('div');
+      title.textContent = item.url;
+      card.appendChild(title);
+      ['d', 't', 'm'].forEach(v => {
+        const img = document.createElement('img');
+        img.src = `shots/${item.id}--${v}.png`;
+        img.dataset.vp = v;
+        if (v === active) { img.classList.add('active'); }
+        card.appendChild(img);
+      });
+      container.appendChild(card);
+    });
+  });
+}
+
+function setViewport(v) {
+  active = v;
+  document.querySelectorAll('.vp-btn').forEach(b => {
+    b.classList.toggle('active', b.dataset.vp === v);
+  });
+  document.querySelectorAll('.card img').forEach(img => {
+    img.classList.toggle('active', img.dataset.vp === v);
+  });
+}
+
+document.getElementById('capture').onclick = () => {
+  const url = document.getElementById('url').value;
+  fetch('/api/capture', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url })
+  }).then(refresh);
+};
+
+document.querySelectorAll('.vp-btn').forEach(btn => {
+  btn.onclick = () => setViewport(btn.dataset.vp);
+});
+
+refresh();

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,7 @@
+body { font-family: sans-serif; margin: 20px; }
+#controls { margin-bottom: 10px; }
+#viewports button { margin-right: 5px; }
+#viewports .active { font-weight: bold; }
+.card { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
+.card img { max-width: 100%; display: none; }
+.card img.active { display: block; }

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,37 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { captureAllViewports } = require('./screenshot');
+
+const router = express.Router();
+const shotsDir = path.join(__dirname, '..', 'public', 'shots');
+
+router.use(express.json());
+
+router.post('/capture', async (req, res) => {
+  const url = req.body.url;
+  if (!url) {
+    res.status(400).json({ error: 'Missing field url; add to body.' });
+    return;
+  }
+
+  const stamp = Date.now().toString();
+  const basePath = path.join(shotsDir, stamp);
+  try {
+    fs.mkdirSync(shotsDir, { recursive: true });
+    const images = await captureAllViewports(url, basePath);
+    const entry = { id: stamp, url, images };
+    store.push(entry);
+    res.json(entry);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/shots', (req, res) => {
+  res.json(store);
+});
+
+const store = [];
+
+module.exports = router;

--- a/src/screenshot.js
+++ b/src/screenshot.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+const VIEWPORTS = {
+  d: { width: 1920, height: 1080 },
+  t: { width: 768, height: 1024 },
+  m: { width: 420, height: 800 },
+};
+
+async function capture(url, filePath, viewport) {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  await page.setViewport(viewport);
+  await page.goto(url, { waitUntil: 'networkidle2' });
+  await page.screenshot({ path: filePath, fullPage: true });
+  await browser.close();
+}
+
+function buildFileName(base, type) {
+  return `${base}--${type}.png`;
+}
+
+async function captureAllViewports(url, baseFile) {
+  if (!url) {
+    throw new Error('Missing field url; add to body.');
+  }
+
+  const promises = [];
+  for (const [key, viewport] of Object.entries(VIEWPORTS)) {
+    const name = buildFileName(baseFile, key);
+    promises.push(capture(url, name, viewport));
+  }
+  await Promise.all(promises);
+
+  const result = {};
+  for (const key of Object.keys(VIEWPORTS)) {
+    result[key] = buildFileName(path.basename(baseFile), key);
+  }
+  return result;
+}
+
+module.exports = { captureAllViewports };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const path = require('path');
+const routes = require('./routes');
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use('/', express.static(path.join(__dirname, '..', 'public')));
+app.use('/api', routes);
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- setup express server with puppeteer
- capture desktop/tablet/mobile screenshots
- serve simple frontend with viewport toggle
- ignore screenshots and dependencies in git
- remove package lock file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e7a7986d483258f354e5d9c7a6dbe