### PR TITLE
Align local capture flow with debug script

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,56 +1,43 @@
-- [x] Layout & IA
-Header crams capture form and five CTAs into a single glassmorphic bar; reorganize into a calm two-pane workspace so controls stop fighting the gallery.
+## Plan
+1. Replace the Express router with a PHP front controller so `/capture`, `/stream`, `/session`, and `/pdf` continue to exist without Node.
 
-:::task-stub{title="Replace crowded header with sidebar layout"}
-1. Redesign `static/index.html` so controls live in a fixed `<aside>` (capture form, session buttons, export actions) and screenshots occupy a `<main>` gallery pane.
-2. Rewire `static/css/style.css` to use CSS Grid for a left sidebar + right content layout; drop ad-hoc flex utility classes.
-3. Adjust `static/js/main.js` queries to match the new element IDs/classes and ensure focus states work without nesting.
+:::task-stub{title="Port HTTP routing to PHP"}
+1. Add `public/index.php` that inspects `$_SERVER['REQUEST_URI']` and `$_SERVER['REQUEST_METHOD']`, returning static assets from `static/` via `mime_content_type` + `readfile`.
+2. Route `/` to `static/index.html`, `/static/...` to files, `/capture`, `/session`, `/pdf`, `/stream`, and `/proxy` to dedicated PHP handlers.
+3. For SSE `/stream`, call `session_write_close()`, loop while `connection_status() === CONNECTION_NORMAL`, `echo` JSON lines, and `flush()` with a 10s ping timer.
 :::
 
-- [x] Visual System
-CSS double-defines `body`, forces full-screen background photos, and stacks heavy shadows; establish a small design token set and accessible theme.
+2. Recreate the session store and disk layout in PHP to mirror the current timestamped directory structure.
 
-:::task-stub{title="Create minimal design system"}
-1. Introduce CSS custom properties in `static/css/style.css` for colors, spacing, and typography; delete duplicate `body` blocks and random Unsplash backgrounds.
-2. Define reusable button, form, and card classes with flat borders, soft elevation, and focus-visible outlines.
-3. Generate a minified build (e.g., via npm script) to regenerate `style.min.css` after cleanup.
+:::task-stub{title="Rebuild session storage in PHP"}
+1. Create `php/session.php` with `session_path()`, `new_session()`, `clear_session()`, `clear_site($host)`, and `list_images()` using `mkdir`, `scandir`, and `unlink`.
+2. Persist the active session ID in `$_SESSION` or a flat file to emulate `current`.
+3. Return JSON payloads identical to the Node responses for `/session` endpoints.
 :::
 
-- [x] Front-end Logic
-`static/js/main.js` owns DOM wiring, SSE lifecycle, screenshot templating, export, and session management in one closure—SRP is broken and hard to test.
+3. Drop the Puppeteer pipeline; reuse the proven html2canvas capture flow on the client and push PNG blobs to PHP for persistence and streaming updates.
 
-:::task-stub{title="Modularize front-end controller"}
-1. Split `static/js/main.js` into ES modules: `events.js` (DOM listeners), `sse.js` (EventSource lifecycle), `gallery.js` (render/update), `actions.js` (save/export/session).
-2. Use dependency injection so modules get DOM refs from a single initializer; ensure each function early-returns on invalid state.
-3. Add lightweight unit tests (Vitest or similar) for URL validation, SSE reconnection, and gallery rendering.
+:::task-stub{title="Move capture workflow client-side with PHP persistence"}
+1. Extract the capture helpers from `static/js/local-app.js` into a shared module (e.g., `static/js/capture.js`) that returns `{ imageData, meta }`.
+2. Update `static/js/main.js`, `static/js/actions.js`, and `static/js/events.js` to iterate sitemap URLs sequentially, call the new capture module, and `POST` base64 payloads to `/capture/store`.
+3. Implement `php/capture.php` endpoints: `GET /capture/sitemap` (proxy `getsitemap`), `POST /capture/store` (write PNG via `file_put_contents`), and `GET /capture/status` (emit progress JSON for the UI without SSE).
 :::
 
-- [x] Interaction Model
-`fpgrab.js` hand-rolls drag momentum with global listeners; feels jittery and fights native scroll.
+4. Replace PDF export and offline bundle tooling with PHP so downloads stay functional without `pdfkit` or Node-based module packaging.
 
-:::task-stub{title="Drop custom grabber for native scroll"}
-1. Delete `static/js/fpgrab.js`; rely on CSS `overflow-x: auto` plus `scroll-snap` for gallery navigation.
-2. If kinetic scroll is still desired, replace with a tiny passive helper that only listens on the gallery element and mutates `scrollLeft`.
-3. Update `static/js/main.js` to remove `templateImageWrap` assumptions tied to transform-based translation.
+:::task-stub{title="Reimplement exports in PHP"}
+1. Add `php/pdf.php` that reads `list_images()`, instantiates `Imagick` (or fallback GD), composites PNGs onto A4 canvases, and streams `application/pdf`.
+2. Expose `/export/pdf` returning 400 when no images exist and 200 with the binary stream otherwise.
+3. Move offline bundle assembly server-side: build HTML via DOMDocument, inline CSS and JS with `file_get_contents`, inline `<img>` tags with base64, and send as downloadable HTML.
 :::
 
-- [x] API & Workflow
-UI calls `/session` POST/DELETE and `/pdf`, but router only exposes `/capture` and `/stream`, so half the controls are dead weight.
+5. Remove Node tooling, configs, and dependencies so the repository is PHP-first.
 
-:::task-stub{title="Implement missing session and export endpoints"}
-1. Add `src/controllers/session.js` to wrap `session.js` helpers; expose POST new-session, DELETE by host, and GET list endpoints via router.
-2. Implement `/pdf` route that streams a generated PDF (e.g., pdfkit) from current session screenshots.
-3. Wire new endpoints into `src/routes.js` and cover with supertest integration tests.
+:::task-stub{title="Retire Node stack"}
+1. Delete `package.json`, `package-lock.json`, `index.js`, and `src/` after PHP parity lands.
+2. Replace README setup instructions with PHP (e.g., `php -S 0.0.0.0:3200 -t public`) and document required extensions/binaries.
+3. Purge `startup.sh` Node steps, keeping only PHP/server prerequisites.
 :::
 
-- [x] Capture Pipeline
-`/capture` fetches the entire sitemap sequentially; each screenshot launches a fresh browser and closes it—slow and brittle.
-
-:::task-stub{title="Introduce browser pool and queued capture"}
-1. Extract Puppeteer lifecycle into `src/browser.js` that maintains a singleton browser and per-request pages; ensure early returns on launch failures.
-2. Replace synchronous `for` loop in `src/routes.js` with a queue that streams progress as soon as each screenshot completes (limit concurrency to keep memory sane).
-3. Extend responses to include error details per URL and update front-end gallery renderer to surface failed entries cleanly.
-:::
-
-- [x] Testing
-Not run (static analysis only).
+## Testing
+- ⚠️ Not run (read-only review)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,43 +1,30 @@
 ## Plan
 1. Replace the Express router with a PHP front controller so `/capture`, `/stream`, `/session`, and `/pdf` continue to exist without Node.
 
-:::task-stub{title="Port HTTP routing to PHP"}
 1. Add `public/index.php` that inspects `$_SERVER['REQUEST_URI']` and `$_SERVER['REQUEST_METHOD']`, returning static assets from `static/` via `mime_content_type` + `readfile`.
 2. Route `/` to `static/index.html`, `/static/...` to files, `/capture`, `/session`, `/pdf`, `/stream`, and `/proxy` to dedicated PHP handlers.
 3. For SSE `/stream`, call `session_write_close()`, loop while `connection_status() === CONNECTION_NORMAL`, `echo` JSON lines, and `flush()` with a 10s ping timer.
-:::
 
 2. Recreate the session store and disk layout in PHP to mirror the current timestamped directory structure.
 
-:::task-stub{title="Rebuild session storage in PHP"}
 1. Create `php/session.php` with `session_path()`, `new_session()`, `clear_session()`, `clear_site($host)`, and `list_images()` using `mkdir`, `scandir`, and `unlink`.
 2. Persist the active session ID in `$_SESSION` or a flat file to emulate `current`.
 3. Return JSON payloads identical to the Node responses for `/session` endpoints.
-:::
 
 3. Drop the Puppeteer pipeline; reuse the proven html2canvas capture flow on the client and push PNG blobs to PHP for persistence and streaming updates.
 
-:::task-stub{title="Move capture workflow client-side with PHP persistence"}
 1. Extract the capture helpers from `static/js/local-app.js` into a shared module (e.g., `static/js/capture.js`) that returns `{ imageData, meta }`.
 2. Update `static/js/main.js`, `static/js/actions.js`, and `static/js/events.js` to iterate sitemap URLs sequentially, call the new capture module, and `POST` base64 payloads to `/capture/store`.
 3. Implement `php/capture.php` endpoints: `GET /capture/sitemap` (proxy `getsitemap`), `POST /capture/store` (write PNG via `file_put_contents`), and `GET /capture/status` (emit progress JSON for the UI without SSE).
-:::
 
 4. Replace PDF export and offline bundle tooling with PHP so downloads stay functional without `pdfkit` or Node-based module packaging.
 
-:::task-stub{title="Reimplement exports in PHP"}
 1. Add `php/pdf.php` that reads `list_images()`, instantiates `Imagick` (or fallback GD), composites PNGs onto A4 canvases, and streams `application/pdf`.
 2. Expose `/export/pdf` returning 400 when no images exist and 200 with the binary stream otherwise.
 3. Move offline bundle assembly server-side: build HTML via DOMDocument, inline CSS and JS with `file_get_contents`, inline `<img>` tags with base64, and send as downloadable HTML.
-:::
 
 5. Remove Node tooling, configs, and dependencies so the repository is PHP-first.
 
-:::task-stub{title="Retire Node stack"}
 1. Delete `package.json`, `package-lock.json`, `index.js`, and `src/` after PHP parity lands.
 2. Replace README setup instructions with PHP (e.g., `php -S 0.0.0.0:3200 -t public`) and document required extensions/binaries.
 3. Purge `startup.sh` Node steps, keeping only PHP/server prerequisites.
-:::
-
-## Testing
-- ⚠️ Not run (read-only review)

--- a/static/js/local-app.js
+++ b/static/js/local-app.js
@@ -7,6 +7,7 @@ const VIEWPORTS = {
     tablet: 834,
     desktop: 1920
 };
+const IMAGE_TIMEOUT_MS = 5000;
 
 let nextFetchReadyAt = 0;
 
@@ -16,9 +17,34 @@ function selectById(id) {
     throw new Error(`Missing element #${id}; fix template.`);
 }
 
-function setStatus(target, message) {
+function writeStatus(target, message) {
     if (!target) return;
     target.textContent = message;
+}
+
+function appendStatus(target, message, detail) {
+    if (!target) return;
+    const stamp = new Date().toISOString();
+    let line = `[${stamp}] ${message}`;
+    const hasDetail = typeof detail !== 'undefined';
+    if (hasDetail) {
+        let payload;
+        try {
+            payload = JSON.stringify(detail);
+        } catch (error) {
+            payload = '"[unserializable]"';
+        }
+        line = `${line} ${payload}`;
+        console.log(line, detail);
+    } else {
+        console.log(line);
+    }
+    const existing = target.textContent;
+    if (!existing) {
+        target.textContent = line;
+        return;
+    }
+    target.textContent = `${existing}\n${line}`;
 }
 
 function deriveHost(url) {
@@ -67,14 +93,42 @@ function createProxyUrl(url) {
     return `${PROXY_ENDPOINT}?url=${encoded}`;
 }
 
+async function waitForNextFetchSlot(statusEl) {
+    const now = Date.now();
+    if (now >= nextFetchReadyAt) return;
+    const waitMs = nextFetchReadyAt - now;
+    appendStatus(statusEl, `→ Waiting ${waitMs}ms before proxy fetch`);
+    await new Promise((resolve) => {
+        window.setTimeout(resolve, waitMs);
+    });
+}
+
+async function fetchSnapshot(url, statusEl) {
+    await waitForNextFetchSlot(statusEl);
+    const proxyUrl = createProxyUrl(url);
+    appendStatus(statusEl, '→ Fetching snapshot', { proxyUrl });
+    const startedAt = performance.now();
+    const response = await fetch(proxyUrl);
+    const elapsedMs = (performance.now() - startedAt).toFixed(1);
+    appendStatus(statusEl, `✓ Fetch ${response.status} in ${elapsedMs} ms`);
+    if (!response.ok) {
+        appendStatus(statusEl, '❌ Proxy fetch failed', { status: response.status });
+        throw new Error(`Proxy fetch failed; status ${response.status}.`);
+    }
+    const html = await response.text();
+    appendStatus(statusEl, '✓ HTML bytes', { length: html.length });
+    return html;
+}
+
 function buildIframe(width) {
     const frame = document.createElement('iframe');
-    frame.style.position = 'absolute';
-    frame.style.left = '-10000px';
-    frame.style.top = '0';
-    frame.style.border = 'none';
+    frame.width = width;
+    frame.height = 100;
     frame.style.width = `${width}px`;
-    frame.style.opacity = '0';
+    frame.style.height = '100px';
+    frame.style.visibility = 'hidden';
+    frame.style.display = 'block';
+    frame.style.border = '0';
     document.body.appendChild(frame);
     return frame;
 }
@@ -87,7 +141,11 @@ function removeIframe(frame) {
 }
 
 function writeHtmlIntoFrame(frame, html) {
-    const doc = frame.contentDocument;
+    let doc = frame.contentDocument;
+    if (!doc) {
+        const win = frame.contentWindow;
+        if (win) doc = win.document;
+    }
     if (!doc) throw new Error('Iframe document missing; browser blocked frame.');
     doc.open();
     doc.write(html);
@@ -95,56 +153,161 @@ function writeHtmlIntoFrame(frame, html) {
     return doc;
 }
 
-function appendViewportStyle(doc, width) {
+function raf() {
+    return new Promise((resolve) => {
+        window.requestAnimationFrame(resolve);
+    });
+}
+
+function freezeAnimations(doc) {
     const style = doc.createElement('style');
-    style.textContent = `html, body { margin:0 !important; padding:0 !important; width:${width}px !important; min-width:${width}px !important; }
-*, *::before, *::after { animation:none !important; transition:none !important; }`;
+    style.textContent = `*,*::before,*::after{animation:none!important;transition:none!important}`;
     let target = doc.head;
     if (!target) target = doc.documentElement;
-    if (!target) throw new Error('Unable to apply viewport style; missing head and root.');
+    if (!target) return;
     target.appendChild(style);
 }
 
-function waitNextFrame() {
-    return new Promise((resolve) => {
-        window.requestAnimationFrame(() => {
-            window.requestAnimationFrame(resolve);
-        });
-    });
+async function settleFonts(doc, statusEl) {
+    const fonts = doc.fonts;
+    if (!fonts) return;
+    const ready = fonts.ready;
+    if (!ready) return;
+    try {
+        await ready;
+        appendStatus(statusEl, '✓ Fonts ready');
+    } catch (error) {
+        appendStatus(statusEl, '⚠ fonts.ready error');
+    }
 }
 
-async function settleFrameContent(doc, width) {
-    appendViewportStyle(doc, width);
-    await waitNextFrame();
-    if (doc.fonts) {
-        const ready = doc.fonts.ready;
-        if (ready) {
-            try {
-                await ready;
-            } catch (error) {
-                // ignore font settle errors
+function settleSingleImage(image, index, statusEl) {
+    return new Promise((resolve) => {
+        if (!image) {
+            resolve();
+            return;
+        }
+        let src = image.currentSrc;
+        if (!src) src = image.src;
+        if (!src) src = '(no src)';
+        const startedAt = performance.now();
+        let settled = false;
+        let timer = null;
+        function finishSuccess(tag) {
+            if (settled) return;
+            settled = true;
+            if (timer) window.clearTimeout(timer);
+            const elapsed = performance.now() - startedAt;
+            appendStatus(statusEl, `✓ img#${index} ${tag}`, { src, ms: elapsed.toFixed(1) });
+            resolve();
+        }
+        function finishFailure(tag) {
+            if (settled) return;
+            settled = true;
+            if (timer) window.clearTimeout(timer);
+            appendStatus(statusEl, `⚠ img#${index} ${tag}`, { src });
+            resolve();
+        }
+        if (image.complete) {
+            const hasSize = image.naturalWidth > 0;
+            if (hasSize) {
+                finishSuccess('complete');
+                return;
             }
         }
-    }
-    let imageList = [];
-    if (doc.images) imageList = Array.from(doc.images);
-    const promises = imageList.map((image) => {
-        if (!image) return Promise.resolve();
-        if (!image.decode) return Promise.resolve();
-        return image.decode().catch(() => {});
+        timer = window.setTimeout(() => {
+            finishFailure('timeout');
+        }, IMAGE_TIMEOUT_MS);
+        const canDecode = typeof image.decode === 'function';
+        if (canDecode) {
+            image.decode().then(() => {
+                finishSuccess('decoded');
+            }).catch(() => {
+                finishFailure('decode error');
+            });
+            return;
+        }
+        image.addEventListener('load', () => {
+            finishSuccess('load');
+        }, { once: true });
+        image.addEventListener('error', () => {
+            finishFailure('error');
+        }, { once: true });
     });
-    await Promise.all(promises);
 }
 
-function computePageHeight(doc) {
+async function settleImages(doc, statusEl) {
+    let images = [];
+    if (doc.images) images = Array.from(doc.images);
+    appendStatus(statusEl, `→ Decoding ${images.length} images (5s timeout each)`);
+    const tasks = images.map((image, index) => settleSingleImage(image, index, statusEl));
+    await Promise.all(tasks);
+    appendStatus(statusEl, '✓ Image settle complete');
+}
+
+async function settleFrame(doc, statusEl) {
+    freezeAnimations(doc);
+    await raf();
+    await raf();
+    await settleFonts(doc, statusEl);
+    await settleImages(doc, statusEl);
+}
+
+function auditGradients(doc, statusEl) {
+    const nodes = doc.querySelectorAll('*');
+    appendStatus(statusEl, '→ Auditing gradients');
+    let seen = 0;
+    for (const node of nodes) {
+        if (!node) continue;
+        const view = doc.defaultView;
+        if (!view) return;
+        const computed = view.getComputedStyle(node);
+        if (!computed) continue;
+        const background = computed.backgroundImage;
+        if (!background) continue;
+        const hasGradient = background.includes('gradient(');
+        if (!hasGradient) continue;
+        const preview = background.slice(0, 180);
+        appendStatus(statusEl, 'gradient bg', {
+            tag: node.tagName,
+            className: node.className,
+            background: `${preview}...`
+        });
+        seen += 1;
+        if (seen >= 30) return;
+    }
+}
+
+function measureViewport(frame, doc, statusEl) {
+    const win = frame.contentWindow;
+    const metrics = {
+        innerWidth: null,
+        clientWidth: null,
+        bodyClient: null
+    };
+    if (win) metrics.innerWidth = win.innerWidth;
+    const root = doc.documentElement;
+    if (root) metrics.clientWidth = root.clientWidth;
+    const body = doc.body;
+    if (body) metrics.bodyClient = body.clientWidth;
+    appendStatus(statusEl, 'Viewport metrics', metrics);
+    return metrics;
+}
+
+function computePageHeight(doc, statusEl) {
     const root = doc.documentElement;
     if (!root) throw new Error('Snapshot missing documentElement; aborting.');
-    const heights = [];
-    heights.push(root.scrollHeight);
-    heights.push(root.offsetHeight);
+    const values = [];
+    values.push(root.scrollHeight);
+    values.push(root.offsetHeight);
     const body = doc.body;
-    if (body) heights.push(body.scrollHeight);
-    return Math.max(...heights);
+    if (body) {
+        values.push(body.scrollHeight);
+        values.push(body.offsetHeight);
+    }
+    const height = Math.max(...values);
+    appendStatus(statusEl, 'Computed doc height', { height });
+    return height;
 }
 
 function ensureHtml2Canvas() {
@@ -152,72 +315,95 @@ function ensureHtml2Canvas() {
     throw new Error('Missing html2canvas global; check script tag.');
 }
 
-async function renderCanvas(doc, width, height) {
+async function renderWithFallback(doc, width, height, statusEl) {
     const html2canvas = ensureHtml2Canvas();
-    return html2canvas(doc.documentElement, {
+    const baseOptions = {
         backgroundColor: '#ffffff',
         useCORS: true,
         allowTaint: false,
         scale: 1,
         windowWidth: width,
         windowHeight: height,
-        foreignObjectRendering: true
-    });
-}
-
-function scheduleFetchCooldown() {
-    nextFetchReadyAt = Date.now() + FETCH_COOLDOWN_MS;
-    console.info(`[local] Cooling down for ${FETCH_COOLDOWN_MS}ms before next fetch.`);
-}
-
-async function waitForNextFetchSlot() {
-    const now = Date.now();
-    if (now >= nextFetchReadyAt) return;
-    const waitMs = nextFetchReadyAt - now;
-    console.info(`[local] Waiting ${waitMs}ms before proxy fetch.`);
-    await new Promise((resolve) => {
-        window.setTimeout(resolve, waitMs);
-    });
-}
-
-async function fetchSnapshot(url) {
-    await waitForNextFetchSlot();
-    const proxyUrl = createProxyUrl(url);
-    console.info('[local] Fetching snapshot via proxy.', { url, proxyUrl });
-    const response = await fetch(proxyUrl);
-    if (!response.ok) {
-        console.error('[local] Proxy fetch failed.', { status: response.status, url });
-        throw new Error(`Proxy fetch failed; status ${response.status}.`);
+        logging: true
+    };
+    appendStatus(statusEl, '→ html2canvas (canvas renderer) start');
+    try {
+        const canvas = await html2canvas(doc.documentElement, {
+            ...baseOptions,
+            foreignObjectRendering: false
+        });
+        appendStatus(statusEl, '✓ html2canvas (canvas) complete');
+        return canvas;
+    } catch (error) {
+        let message = 'Unknown error';
+        if (error) {
+            if (error.message) message = error.message;
+        }
+        appendStatus(statusEl, '⚠ html2canvas (canvas) failed', { message });
+        appendStatus(statusEl, '→ html2canvas (foreignObject) fallback start');
+        const fallback = await html2canvas(doc.documentElement, {
+            ...baseOptions,
+            foreignObjectRendering: true
+        });
+        appendStatus(statusEl, '✓ html2canvas (foreignObject) complete');
+        return fallback;
     }
-    const text = await response.text();
-    console.info('[local] Snapshot fetched.', { url, bytes: text.length });
-    return text;
 }
 
-function validateUrl(value) {
-    if (!value) throw new Error('Missing field url; add to form.');
-    const trimmed = value.trim();
-    if (!/^https?:\/\//i.test(trimmed)) throw new Error('Invalid URL; include http or https prefix.');
-    return trimmed;
+function scheduleFetchCooldown(statusEl) {
+    nextFetchReadyAt = Date.now() + FETCH_COOLDOWN_MS;
+    appendStatus(statusEl, `→ Cooling down for ${FETCH_COOLDOWN_MS}ms before next fetch`);
+}
+
+function waitForIframeLoad(frame, statusEl) {
+    return new Promise((resolve) => {
+        let settled = false;
+        const timer = window.setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            appendStatus(statusEl, '⚠ iframe load timeout (continuing)');
+            resolve();
+        }, 8000);
+        frame.onload = () => {
+            if (settled) return;
+            settled = true;
+            window.clearTimeout(timer);
+            appendStatus(statusEl, '✓ iframe onload');
+            resolve();
+        };
+    });
 }
 
 async function capturePage(params) {
     const { url, mode, width, statusEl, gallery } = params;
-    console.info('[local] Capture requested.', { url, mode, width });
-    setStatus(statusEl, 'Fetching pre-inlined snapshot via proxy…');
-    const html = await fetchSnapshot(url);
-    setStatus(statusEl, 'Rendering snapshot in hidden iframe…');
+    writeStatus(statusEl, '');
+    appendStatus(statusEl, '→ Capture requested', { url, mode, width });
+    const html = await fetchSnapshot(url, statusEl);
+    appendStatus(statusEl, '→ Building iframe', { width });
     const frame = buildIframe(width);
     try {
         const doc = writeHtmlIntoFrame(frame, html);
-        console.info('[local] Snapshot written to iframe.', { url, mode });
-        await settleFrameContent(doc, width);
-        console.info('[local] Frame content settled.', { url });
-        const height = computePageHeight(doc);
+        appendStatus(statusEl, '✓ HTML written to iframe');
+        await waitForIframeLoad(frame, statusEl);
+        await settleFrame(doc, statusEl);
+        appendStatus(statusEl, '✓ Frame content settled');
+        auditGradients(doc, statusEl);
+        const metrics = measureViewport(frame, doc, statusEl);
+        let mismatch = false;
+        if (metrics.innerWidth !== width) mismatch = true;
+        if (metrics.clientWidth !== width) mismatch = true;
+        if (mismatch) {
+            appendStatus(statusEl, '⚠ Viewport mismatch; reassert width', metrics);
+            frame.width = width;
+            frame.style.width = `${width}px`;
+            await raf();
+            await raf();
+            measureViewport(frame, doc, statusEl);
+        }
+        const height = computePageHeight(doc, statusEl);
+        frame.height = height;
         frame.style.height = `${height}px`;
-        setStatus(statusEl, 'Capturing screenshot via html2canvas…');
-        const canvas = await renderCanvas(doc, width, height);
-        console.info('[local] Canvas rendered.', { url, width, height });
+        const canvas = await renderWithFallback(doc, width, height, statusEl);
         const dataUrl = canvas.toDataURL('image/png');
         let title = doc.title;
         if (!title) title = 'Captured page';
@@ -230,9 +416,8 @@ async function capturePage(params) {
             dimensions: { width, height }
         };
         gallery.append(image);
-        console.info('[local] Capture stored in gallery.', { url, mode });
-        setStatus(statusEl, `Screenshot complete (${width} × ${height}).`);
-        scheduleFetchCooldown();
+        appendStatus(statusEl, `✓ Done (${width} × ${height})`);
+        scheduleFetchCooldown(statusEl);
     } finally {
         removeIframe(frame);
     }
@@ -253,7 +438,9 @@ function initSidebar(appShell, sidebar, toggleBtn, labelEl, iconEl) {
     let prefersCollapsed = false;
     if (window.matchMedia) {
         const query = window.matchMedia('(max-width: 960px)');
-        if (query && query.matches) prefersCollapsed = true;
+        if (query) {
+            if (query.matches) prefersCollapsed = true;
+        }
     }
     if (prefersCollapsed) initial = 'collapsed';
     applyState(initial);
@@ -266,6 +453,33 @@ function initSidebar(appShell, sidebar, toggleBtn, labelEl, iconEl) {
         }
         applyState('collapsed');
     });
+}
+
+function validateUrl(value) {
+    if (!value) throw new Error('Missing field url; add to form.');
+    const trimmed = value.trim();
+    const pattern = /^https?:\/\//i;
+    if (!pattern.test(trimmed)) throw new Error('Invalid URL; include http or https prefix.');
+    return trimmed;
+}
+
+async function handleCapture(form, urlInput, modeInputs, statusEl, gallery) {
+    try {
+        disableForm(form, true);
+        const url = validateUrl(urlInput.value);
+        const mode = readMode(modeInputs);
+        const width = resolveViewportWidth(mode);
+        await capturePage({ url, mode, width, statusEl, gallery });
+    } catch (error) {
+        console.error(error);
+        let message = 'Capture failed; check console.';
+        if (error) {
+            if (error.message) message = error.message;
+        }
+        appendStatus(statusEl, `Error: ${message}`);
+    } finally {
+        disableForm(form, false);
+    }
 }
 
 function init() {
@@ -283,38 +497,59 @@ function init() {
     const sidebarToggleIcon = document.getElementById('sidebarToggleIcon');
     const modeInputs = document.querySelectorAll('input[name="mode"]');
 
+    if (statusEl) {
+        if (!statusEl.style.whiteSpace) statusEl.style.whiteSpace = 'pre-line';
+    }
+
     const gallery = createGallery(galleryContainer);
-    setStatus(statusEl, 'Idle. Ready for local capture.');
+    writeStatus(statusEl, 'Idle. Ready for local capture.');
 
     initSidebar(appShell, sidebar, sidebarToggleBtn, sidebarToggleLabel, sidebarToggleIcon);
 
     newSessionBtn.addEventListener('click', () => {
         gallery.clear();
-        setStatus(statusEl, 'Session reset.');
+        writeStatus(statusEl, 'Session reset.');
     });
 
     clearGalleryBtn.addEventListener('click', () => {
         gallery.clear();
-        setStatus(statusEl, 'Gallery cleared.');
+        writeStatus(statusEl, 'Gallery cleared.');
     });
 
     form.addEventListener('submit', async (event) => {
         event.preventDefault();
-        try {
-            disableForm(form, true);
-            const url = validateUrl(urlInput.value);
-            const mode = readMode(modeInputs);
-            const width = resolveViewportWidth(mode);
-            await capturePage({ url, mode, width, statusEl, gallery });
-        } catch (error) {
-            console.error(error);
-            const message = error && error.message ? error.message : 'Capture failed; check console.';
-            setStatus(statusEl, `Error: ${message}`);
-        } finally {
-            disableForm(form, false);
-        }
+        await handleCapture(form, urlInput, modeInputs, statusEl, gallery);
     });
 }
+
+function patchAddColorStop() {
+    try {
+        const ctor = window.CanvasGradient;
+        if (!ctor) return;
+        const proto = ctor.prototype;
+        if (!proto) return;
+        if (proto.__patched__) return;
+        const original = proto.addColorStop;
+        if (!original) return;
+        proto.addColorStop = function addColorStop(offset, color) {
+            let value = Number(offset);
+            if (!Number.isFinite(value)) value = 0;
+            if (value < 0) value = 0;
+            if (value > 1) value = 1;
+            let finalColor = color;
+            const isString = typeof finalColor === 'string';
+            if (!isString) finalColor = 'rgba(0,0,0,0)';
+            if (!finalColor) finalColor = 'rgba(0,0,0,0)';
+            return original.call(this, value, finalColor);
+        };
+        proto.__patched__ = true;
+        console.info('[local] Patched CanvasGradient.addColorStop guard.');
+    } catch (error) {
+        console.warn('[local] Failed to patch addColorStop (non-fatal).', error);
+    }
+}
+
+patchAddColorStop();
 
 if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);

--- a/static/js/local-app.js
+++ b/static/js/local-app.js
@@ -1,7 +1,7 @@
 import { createGallery } from 'app/gallery';
 
 const PROXY_ENDPOINT = 'https://testing2.funkpd.shop/cors.php';
-const FETCH_COOLDOWN_MS = 300000;
+const FETCH_COOLDOWN_MS = 5000;
 const VIEWPORTS = {
     mobile: 390,
     tablet: 834,
@@ -20,6 +20,7 @@ function selectById(id) {
 function writeStatus(target, message) {
     if (!target) return;
     target.textContent = message;
+    target.scrollTop = target.scrollHeight;
 }
 
 function appendStatus(target, message, detail) {
@@ -42,9 +43,11 @@ function appendStatus(target, message, detail) {
     const existing = target.textContent;
     if (!existing) {
         target.textContent = line;
+        target.scrollTop = target.scrollHeight;
         return;
     }
     target.textContent = `${existing}\n${line}`;
+    target.scrollTop = target.scrollHeight;
 }
 
 function deriveHost(url) {
@@ -129,6 +132,10 @@ function buildIframe(width) {
     frame.style.visibility = 'hidden';
     frame.style.display = 'block';
     frame.style.border = '0';
+    frame.style.position = 'absolute';
+    frame.style.left = '-10000px';
+    frame.style.top = '0';
+    frame.style.pointerEvents = 'none';
     document.body.appendChild(frame);
     return frame;
 }
@@ -297,15 +304,12 @@ function measureViewport(frame, doc, statusEl) {
 function computePageHeight(doc, statusEl) {
     const root = doc.documentElement;
     if (!root) throw new Error('Snapshot missing documentElement; aborting.');
-    const values = [];
-    values.push(root.scrollHeight);
-    values.push(root.offsetHeight);
     const body = doc.body;
-    if (body) {
-        values.push(body.scrollHeight);
-        values.push(body.offsetHeight);
-    }
-    const height = Math.max(...values);
+    const scrollHeight = root.scrollHeight;
+    const offsetHeight = root.offsetHeight;
+    let bodyScroll = 0;
+    if (body) bodyScroll = body.scrollHeight;
+    const height = Math.max(scrollHeight, offsetHeight, bodyScroll);
     appendStatus(statusEl, 'Computed doc height', { height });
     return height;
 }
@@ -499,6 +503,9 @@ function init() {
 
     if (statusEl) {
         if (!statusEl.style.whiteSpace) statusEl.style.whiteSpace = 'pre-line';
+        if (!statusEl.style.maxHeight) statusEl.style.maxHeight = '200px';
+        if (!statusEl.style.overflowY) statusEl.style.overflowY = 'auto';
+        if (!statusEl.style.paddingRight) statusEl.style.paddingRight = '8px';
     }
 
     const gallery = createGallery(galleryContainer);

--- a/static/local.html
+++ b/static/local.html
@@ -58,7 +58,7 @@
                 <p class="field__help">Captures happen in your browser. Expect long waits on large pages.</p>
             </section>
             <footer class="sidebar__footer" aria-live="polite">
-                <p id="sessionStatus" class="sidebar__status">Idle.</p>
+                <p id="sessionStatus" class="sidebar__status" style="white-space: pre-line;">Idle.</p>
             </footer>
         </aside>
         <main class="gallery" aria-live="polite" aria-label="Screenshot gallery">


### PR DESCRIPTION
## Summary
- rewrite the local capture pipeline to mirror the working debug harness, including iframe settling, gradient auditing, and html2canvas fallback handling
- enhance status logging in local mode and support multi-line output in the sidebar footer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5d675fd948325987a0f6fc8607317