### PR TITLE
Normalize sitemap URLs before capture

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -17,6 +17,16 @@ function broadcast(payload) {
     }
 }
 
+function safeHostname(value) {
+    if (!value) return '';
+    try {
+        const parsed = new URL(value);
+        return parsed.hostname;
+    } catch (error) {
+        return '';
+    }
+}
+
 async function processCapture(urls, cookie, mode) {
     const tasks = [];
     for (const target of urls) {
@@ -28,7 +38,7 @@ async function processCapture(urls, cookie, mode) {
             } catch (error) {
                 const failure = {
                     status: 'error',
-                    host: new URL(target).hostname,
+                    host: safeHostname(target),
                     pageUrl: target,
                     mode,
                     error: error.message

--- a/src/sitemap.js
+++ b/src/sitemap.js
@@ -1,15 +1,82 @@
 import fetch from 'node-fetch';
+
+function readEntry(input) {
+    if (!input) return '';
+    const kind = typeof input;
+    if (kind === 'string') {
+        const trimmed = input.trim();
+        if (trimmed) return trimmed;
+        return '';
+    }
+    if (kind !== 'object') return '';
+    const locValue = input.loc;
+    const locMissing = typeof locValue === 'undefined';
+    if (!locMissing) {
+        const locString = String(locValue).trim();
+        if (locString) return locString;
+    }
+    const urlValue = input.url;
+    const urlMissing = typeof urlValue === 'undefined';
+    if (!urlMissing) {
+        const urlString = String(urlValue).trim();
+        if (urlString) return urlString;
+    }
+    return '';
+}
+
+function absolutize(baseUrl, raw) {
+    if (!raw) return '';
+    try {
+        const parsed = new URL(raw, baseUrl);
+        const href = parsed.toString();
+        const isHttp = parsed.protocol === 'http:';
+        if (isHttp) return href;
+        const isHttps = parsed.protocol === 'https:';
+        if (isHttps) return href;
+        return '';
+    } catch (error) {
+        return '';
+    }
+}
+
+export function normalizeSitemapEntries(baseUrl, entries) {
+    if (!entries) return [];
+    let list = [];
+    const arrayInput = Array.isArray(entries);
+    if (arrayInput) {
+        list = entries;
+    } else {
+        list = [entries];
+    }
+    const unique = new Set();
+    for (const item of list) {
+        const candidate = readEntry(item);
+        if (!candidate) continue;
+        const absolute = absolutize(baseUrl, candidate);
+        if (!absolute) continue;
+        const seen = unique.has(absolute);
+        if (seen) continue;
+        unique.add(absolute);
+    }
+    return Array.from(unique);
+}
+
 export async function fetchSitemap(url) {
     const response = await fetch(`https://getsitemap.funkpd.com/json?url=${url}`);
     if (!response.ok) {
         throw new Error(`Bad response ${response.status}`);
     }
     const data = await response.json();
-    if (!data.sitemap) {
+    if (!data) {
         throw new Error('Missing sitemap in response');
     }
-    if (data.sitemap.length === 0) {
+    const sitemap = data.sitemap;
+    if (!sitemap) {
+        throw new Error('Missing sitemap in response');
+    }
+    const urls = normalizeSitemapEntries(url, sitemap);
+    if (!urls.length) {
         throw new Error('Empty sitemap');
     }
-    return data.sitemap;
+    return urls;
 }

--- a/test/sitemap.test.js
+++ b/test/sitemap.test.js
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeSitemapEntries } from '../src/sitemap.js';
+
+test('normalizeSitemapEntries resolves relative sitemap entries', () => {
+    const baseUrl = 'https://example.com/root/page';
+    const entries = [
+        'https://example.com/',
+        '/about',
+        { loc: '/contact' },
+        { url: 'https://example.com/pricing' },
+        '/about',
+        null,
+        { loc: '' }
+    ];
+    const result = normalizeSitemapEntries(baseUrl, entries);
+    assert.deepEqual(result, [
+        'https://example.com/',
+        'https://example.com/about',
+        'https://example.com/contact',
+        'https://example.com/pricing'
+    ]);
+});
+
+test('normalizeSitemapEntries skips invalid values', () => {
+    const baseUrl = 'https://example.com/';
+    const entries = [
+        undefined,
+        '',
+        { foo: 'bar' },
+        '   ',
+        'mailto:info@example.com'
+    ];
+    const result = normalizeSitemapEntries(baseUrl, entries);
+    assert.deepEqual(result, []);
+});


### PR DESCRIPTION
## Summary
- normalize sitemap entries from the external service into absolute HTTP(S) URLs and drop duplicates
- guard capture failure reporting against invalid targets to avoid crashing the queue
- add unit coverage for sitemap normalization edge cases

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68f5e3c5c3b48325b274f29b626f6216