### PR TITLE
Handle invalid sitemap URLs gracefully

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -17,6 +17,19 @@ function broadcast(payload) {
     }
 }
 
+function resolveHostname(url) {
+    if (!url) return '';
+    let parsed;
+    try {
+        parsed = new URL(url);
+    } catch (error) {
+        return '';
+    }
+    const host = parsed.hostname;
+    if (!host) return '';
+    return host;
+}
+
 async function processCapture(urls, cookie, mode) {
     const tasks = [];
     for (const target of urls) {
@@ -26,12 +39,16 @@ async function processCapture(urls, cookie, mode) {
                 broadcast({ imageData });
                 return imageData;
             } catch (error) {
+                let message = 'Unknown capture error.';
+                if (error) {
+                    if (error.message) message = error.message;
+                }
                 const failure = {
                     status: 'error',
-                    host: new URL(target).hostname,
+                    host: resolveHostname(target),
                     pageUrl: target,
                     mode,
-                    error: error.message
+                    error: message
                 };
                 broadcast({ imageData: failure });
                 return failure;


### PR DESCRIPTION
## Summary
- add a safe hostname resolver for sitemap entries
- prevent the capture pipeline from throwing when hostname parsing fails

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68f5e6f9a41883258d2c19bd3210b91c