### PR TITLE
Build client-side offline bundle generator

### DIFF
--- a/php/offline.php
+++ b/php/offline.php
@@ -4,143 +4,20 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/util.php';
 require_once __DIR__ . '/session.php';
-
-function safe_text(string $value): string
-{
-    return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-}
-
-function load_style_sheet(): string
-{
-    $path = __DIR__ . '/../static/css/style.min.css';
-    if (!file_exists($path)) {
-        return '';
-    }
-    $css = file_get_contents($path);
-    if ($css === false) {
-        return '';
-    }
-    return $css;
-}
-
-function build_image_card(array $entry): string
-{
-    $meta = [];
-    if (isset($entry['meta'])) {
-        if (is_array($entry['meta'])) {
-            $meta = $entry['meta'];
-        }
-    }
-    $pageUrl = '';
-    if (isset($meta['pageUrl'])) {
-        if (is_string($meta['pageUrl'])) {
-            $pageUrl = $meta['pageUrl'];
-        }
-    }
-    $pageTitle = 'Captured page';
-    if (isset($meta['pageTitle'])) {
-        if (is_string($meta['pageTitle'])) {
-            $pageTitle = $meta['pageTitle'];
-        }
-    }
-    $mode = 'desktop';
-    if (isset($meta['mode'])) {
-        if (is_string($meta['mode'])) {
-            $mode = $meta['mode'];
-        }
-    }
-    $host = '';
-    if (isset($entry['host'])) {
-        if (is_string($entry['host'])) {
-            $host = $entry['host'];
-        }
-    }
-    $path = '';
-    if (isset($entry['filepath'])) {
-        if (is_string($entry['filepath'])) {
-            $path = $entry['filepath'];
-        }
-    }
-    if ($path === '') {
-        return '';
-    }
-    if (!file_exists($path)) {
-        return '';
-    }
-    $binary = file_get_contents($path);
-    if ($binary === false) {
-        return '';
-    }
-    $encoded = base64_encode($binary);
-    $dataUrl = 'data:image/png;base64,' . $encoded;
-    $modeLabel = ucfirst(strtolower($mode));
-    $card = "<article class=\"card\">\n";
-    $card .= "  <header class=\"card__meta\">\n";
-    if ($host !== '') {
-        $card .= '    <p class="card__title">' . safe_text($host) . "</p>\n";
-    }
-    $card .= '    <span class="card__badge">' . safe_text($modeLabel) . "</span>\n";
-    $card .= "  </header>\n";
-    $card .= '  <img class="card__media" src="' . $dataUrl . '" alt="' . safe_text($pageTitle) . '" />' . "\n";
-    $card .= "  <div class=\"card__actions\">\n";
-    if ($pageUrl !== '') {
-        $card .= '    <a href="' . safe_text($pageUrl) . '" target="_blank" rel="noopener">View page</a>' . "\n";
-    }
-    $card .= '    <a href="' . $dataUrl . '" download>Download image</a>' . "\n";
-    $card .= "  </div>\n";
-    $card .= "</article>\n";
-    return $card;
-}
+require_once __DIR__ . '/capture.php';
 
 function offline_handle_export(): void
 {
-    $images = list_images();
+    $payload = capture_session_state();
+    $images = [];
+    if (isset($payload['images'])) {
+        if (is_array($payload['images'])) {
+            $images = $payload['images'];
+        }
+    }
     if (empty($images)) {
         respond_error(400, 'No screenshots captured; run a capture first.');
         return;
     }
-    $cards = '';
-    foreach ($images as $entry) {
-        $card = build_image_card($entry);
-        if ($card === '') {
-            continue;
-        }
-        $cards .= $card;
-    }
-    if ($cards === '') {
-        respond_error(500, 'Failed to inline screenshots for offline bundle.');
-        return;
-    }
-    $summary = session_summary();
-    $style = load_style_sheet();
-    $html = "<!DOCTYPE html>\n";
-    $html .= "<html lang=\"en\">\n";
-    $html .= "<head>\n";
-    $html .= "  <meta charset=\"UTF-8\">\n";
-    $html .= "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n";
-    $html .= "  <title>Screenshot Pro Offline Bundle</title>\n";
-    if ($style !== '') {
-        $html .= "  <style>" . $style . "</style>\n";
-    }
-    $html .= "</head>\n";
-    $html .= "<body>\n";
-    $html .= "  <main class=\"stack stack--lg\" style=\"padding:24px;max-width:1200px;margin:0 auto;\">\n";
-    $html .= "    <header class=\"stack stack--sm\">\n";
-    $html .= "      <h1>Screenshot Pro Offline Bundle</h1>\n";
-    $sessionId = '';
-    if (isset($summary['id'])) {
-        $sessionId = (string) $summary['id'];
-    }
-    $html .= '      <p>Session ' . safe_text($sessionId) . "</p>\n";
-    $html .= "    </header>\n";
-    $html .= "    <section class=\"gallery__grid\">\n";
-    $html .= $cards;
-    $html .= "    </section>\n";
-    $html .= "  </main>\n";
-    $html .= "</body>\n";
-    $html .= "</html>";
-    header('Content-Type: text/html; charset=UTF-8');
-    header('Content-Disposition: attachment; filename="screenshot-pro.html"');
-    header('Content-Length: ' . strlen($html));
-    echo $html;
+    respond_json(200, $payload);
 }

--- a/static/index.html
+++ b/static/index.html
@@ -13,7 +13,8 @@
                 "app/gallery": "/static/js/gallery.js",
                 "app/actions": "/static/js/actions.js",
                 "app/events": "/static/js/events.js",
-                "app/capture": "/static/js/capture.js"
+                "app/capture": "/static/js/capture.js",
+                "app/offline": "/static/js/offline.js"
             }
         }
     </script>

--- a/static/js/actions.js
+++ b/static/js/actions.js
@@ -1,3 +1,5 @@
+import { buildOfflineBundle } from 'app/offline';
+
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 function ensureOk(response, errorMessage) {
@@ -103,10 +105,19 @@ export async function downloadPdf() {
 }
 
 export async function saveOfflineBundle() {
-    const response = await fetch('/export/offline');
-    ensureOk(response, 'Offline bundle export failed.');
-    const blob = await response.blob();
-    downloadBlob(blob, 'screenshot-pro.html');
+    const bundle = await buildOfflineBundle();
+    if (!bundle) {
+        throw new Error('Offline bundle builder returned no data.');
+    }
+    if (!bundle.html) {
+        throw new Error('Offline bundle missing HTML content.');
+    }
+    let filename = 'screenshot-pro.html';
+    if (bundle.filename) {
+        filename = bundle.filename;
+    }
+    const blob = new Blob([bundle.html], { type: 'text/html;charset=UTF-8' });
+    downloadBlob(blob, filename);
 }
 
 export { normalizeMode };

--- a/static/js/offline.js
+++ b/static/js/offline.js
@@ -1,0 +1,182 @@
+import { describeImage } from 'app/gallery';
+
+const MANIFEST_ENDPOINT = '/export/offline';
+const STYLE_PATH = '/static/css/style.min.css';
+const DOWNLOAD_NAME = 'screenshot-pro.html';
+
+function ensureOk(response, message) {
+    if (response.ok) return response;
+    throw new Error(message);
+}
+
+async function fetchManifest() {
+    const response = await fetch(MANIFEST_ENDPOINT);
+    ensureOk(response, 'Offline manifest request failed.');
+    return response.json();
+}
+
+async function fetchStyleSheet() {
+    const response = await fetch(STYLE_PATH);
+    ensureOk(response, 'Failed to load offline stylesheet.');
+    return response.text();
+}
+
+function readBlobAsDataUrl(blob) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            const value = reader.result;
+            if (typeof value !== 'string') {
+                reject(new Error('Failed to encode screenshot as data URL.'));
+                return;
+            }
+            resolve(value);
+        };
+        reader.onerror = () => {
+            reject(new Error('Failed to read screenshot blob.'));
+        };
+        reader.readAsDataURL(blob);
+    });
+}
+
+async function loadScreenshot(url) {
+    const response = await fetch(url);
+    ensureOk(response, `Failed to fetch screenshot; url=${url}.`);
+    const blob = await response.blob();
+    return readBlobAsDataUrl(blob);
+}
+
+function escapeHtml(value) {
+    if (value === undefined) return '';
+    if (value === null) return '';
+    const text = String(value);
+    if (text === '') return '';
+    const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+    let escaped = '';
+    for (const char of text) {
+        const replacement = map[char];
+        if (replacement) {
+            escaped += replacement;
+            continue;
+        }
+        escaped += char;
+    }
+    return escaped;
+}
+
+function buildImageCardHtml(meta, dataUrl) {
+    const lines = [];
+    lines.push('<article class="card">');
+    let hasHeader = false;
+    if (meta.host !== '') {
+        hasHeader = true;
+    }
+    if (!hasHeader) {
+        if (meta.modeLabel !== '') {
+            hasHeader = true;
+        }
+    }
+    if (hasHeader) {
+        lines.push('  <header class="card__meta">');
+        if (meta.host !== '') {
+            lines.push(`    <p class="card__title">${escapeHtml(meta.host)}</p>`);
+        }
+        if (meta.modeLabel !== '') {
+            lines.push(`    <span class="card__badge">${escapeHtml(meta.modeLabel)}</span>`);
+        }
+        lines.push('  </header>');
+    }
+    const attrs = [];
+    attrs.push('class="card__media"');
+    attrs.push(`src="${escapeHtml(dataUrl)}"`);
+    attrs.push(`alt="${escapeHtml(meta.pageTitle)}"`);
+    const width = meta.dimensions.width;
+    if (Number.isFinite(width)) {
+        attrs.push(`width="${width}"`);
+    }
+    const height = meta.dimensions.height;
+    if (Number.isFinite(height)) {
+        attrs.push(`height="${height}"`);
+    }
+    lines.push(`  <img ${attrs.join(' ')} />`);
+    lines.push('  <div class="card__actions">');
+    if (meta.pageUrl !== '') {
+        lines.push(`    <a href="${escapeHtml(meta.pageUrl)}" target="_blank" rel="noopener">View page</a>`);
+    }
+    lines.push(`    <a href="${escapeHtml(dataUrl)}" download>Download image</a>`);
+    lines.push('  </div>');
+    lines.push('</article>');
+    return lines.join('\n');
+}
+
+function resolveSessionId(session) {
+    if (!session) return '';
+    if (typeof session.id !== 'string') return '';
+    return session.id;
+}
+
+function buildDocumentHtml(style, session, cards) {
+    const id = resolveSessionId(session);
+    const lines = [];
+    lines.push('<!DOCTYPE html>');
+    lines.push('<html lang="en">');
+    lines.push('<head>');
+    lines.push('  <meta charset="UTF-8">');
+    lines.push('  <meta name="viewport" content="width=device-width, initial-scale=1.0">');
+    lines.push('  <title>Screenshot Pro Offline Bundle</title>');
+    if (style !== '') {
+        lines.push(`  <style>${style}</style>`);
+    }
+    lines.push('</head>');
+    lines.push('<body>');
+    lines.push('  <main class="stack stack--lg" style="padding:24px;max-width:1200px;margin:0 auto;">');
+    lines.push('    <header class="stack stack--sm">');
+    lines.push('      <h1>Screenshot Pro Offline Bundle</h1>');
+    lines.push(`      <p>Session ${escapeHtml(id)}</p>`);
+    lines.push('    </header>');
+    lines.push('    <section class="gallery__grid">');
+    for (const card of cards) {
+        lines.push(card);
+    }
+    lines.push('    </section>');
+    lines.push('  </main>');
+    lines.push('</body>');
+    lines.push('</html>');
+    return lines.join('\n');
+}
+
+function normalizeImages(list) {
+    if (!Array.isArray(list)) return [];
+    const normalized = [];
+    for (const image of list) {
+        try {
+            const meta = describeImage(image);
+            normalized.push(meta);
+        } catch (error) {
+            console.error(error);
+        }
+    }
+    return normalized;
+}
+
+export async function buildOfflineBundle() {
+    const manifest = await fetchManifest();
+    if (!manifest) throw new Error('Offline manifest payload empty.');
+    const css = await fetchStyleSheet();
+    const images = normalizeImages(manifest.images);
+    if (!images.length) throw new Error('No screenshots captured; run a capture first.');
+    const cards = [];
+    for (const image of images) {
+        const dataUrl = await loadScreenshot(image.imageUrl);
+        const card = buildImageCardHtml(image, dataUrl);
+        cards.push(card);
+    }
+    const html = buildDocumentHtml(css, manifest.session, cards);
+    return { html, filename: DOWNLOAD_NAME };
+}


### PR DESCRIPTION
## Summary
- replace the PHP offline export with a JSON manifest response
- add a browser helper that assembles the offline HTML bundle and wire it into the existing action
- expose gallery metadata helpers needed to rebuild cards in the offline HTML

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6080fb96483258b074dc3c101f493