### PR TITLE
Replace module scripts with vanilla JS

### DIFF
--- a/cors.php
+++ b/cors.php
@@ -1,0 +1,167 @@
+<?php
+// cors.php — self-hosted CORS inliner with local cache and media preservation
+// This is just a reference file, the real file is on a different server.
+
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Headers: *');
+header('Access-Control-Allow-Methods: GET, OPTIONS');
+header('Content-Type: text/html; charset=utf-8');
+
+$url = isset($_GET['url']) ? trim($_GET['url']) : '';
+if ($url === '' || !preg_match('#^https?://#i', $url)) {
+    http_response_code(400);
+    exit('Usage: ?url=https://example.com');
+}
+
+$CACHE_DIR = __DIR__ . '/cache';
+if (!is_dir($CACHE_DIR)) mkdir($CACHE_DIR, 0755, true);
+
+function cache_path($url) {
+    global $CACHE_DIR;
+    return $CACHE_DIR . '/' . sha1($url) . '.bin';
+}
+
+function fetch_cached($url, $binary = false) {
+    $cache = cache_path($url);
+    if (file_exists($cache)) return [file_get_contents($cache), mime_content_type($cache) ?: ''];
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_CONNECTTIMEOUT => 8,
+        CURLOPT_TIMEOUT => 20,
+        CURLOPT_MAXREDIRS => 5,
+        CURLOPT_USERAGENT => 'CORS-InlineProxy/2.0',
+        CURLOPT_ENCODING => '',
+    ]);
+    $data  = curl_exec($ch);
+    $ctype = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+    $code  = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($data === false || $code >= 400) return [null, null];
+    file_put_contents($cache, $data);
+    file_put_contents($cache . '.mime', $ctype);
+    return [$data, $ctype];
+}
+
+function resolve_url($base, $rel) {
+    if ($rel === '' || preg_match('#^https?://$#i', $rel)) return null;
+    if (preg_match('#^[a-z][a-z0-9+\-.]*://#i', $rel)) return $rel;
+    if (strpos($rel, '//') === 0) {
+        $scheme = parse_url($base, PHP_URL_SCHEME) ?: 'https';
+        return $scheme . ':' . $rel;
+    }
+    $bp = parse_url($base);
+    if (!$bp || empty($bp['scheme']) || empty($bp['host'])) return null;
+    $dir = preg_replace('#/[^/]*$#', '/', $bp['path'] ?? '/');
+    $path = ($rel[0] === '/') ? $rel : $dir . $rel;
+    $segs = [];
+    foreach (explode('/', $path) as $seg) {
+        if ($seg === '' || $seg === '.') continue;
+        if ($seg === '..') { array_pop($segs); continue; }
+        $segs[] = $seg;
+    }
+    return "{$bp['scheme']}://{$bp['host']}" . (isset($bp['port']) ? ":{$bp['port']}" : '') . '/' . implode('/', $segs);
+}
+
+function inline_css_assets($css, $base) {
+    // Inline @import while preserving media lists
+    $css = preg_replace_callback(
+        '/@import\s+(?:url\()?["\']?([^"\')]+)["\']?\)?\s*([^;]*);/i',
+        function ($m) use ($base) {
+            $href = $m[1];
+            $mediaList = trim($m[2] ?? '');
+            $sub = resolve_url($base, $href);
+            if (!$sub) return '';
+            [$subCss] = fetch_cached($sub);
+            if (!$subCss) return '';
+            $inlined = inline_css_assets($subCss, $sub);
+            if ($mediaList !== '') return "@media {$mediaList} {\n{$inlined}\n}";
+            return $inlined;
+        },
+        $css
+    );
+
+    // Inline assets in url()
+    $css = preg_replace_callback(
+        '/url\(\s*[\'"]?([^\'")]+)[\'"]?\s*\)/i',
+        function ($m) use ($base) {
+            $src = trim($m[1]);
+            if ($src === '' || preg_match('#^(data:|about:|blob:)#i', $src)) return $m[0];
+            $u = resolve_url($base, $src);
+            if (!$u) return $m[0];
+            [$bin, $ctype] = fetch_cached($u, true);
+            if (!$bin) return $m[0];
+            $mime = $ctype ?: 'application/octet-stream';
+            return 'url("data:' . $mime . ';base64,' . base64_encode($bin) . '")';
+        },
+        $css
+    );
+
+    return $css;
+}
+
+[$html] = fetch_cached($url);
+if (!$html) exit('Fetch failed');
+
+libxml_use_internal_errors(true);
+$dom = new DOMDocument('1.0', 'UTF-8');
+$dom->loadHTML('<?xml encoding="utf-8" ?>' . $html, LIBXML_NOWARNING | LIBXML_NOERROR | LIBXML_NONET);
+$xpath = new DOMXPath($dom);
+
+// remove strict CSP
+foreach ($xpath->query("//meta[translate(@http-equiv,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='content-security-policy']") as $meta) {
+    $meta->parentNode->removeChild($meta);
+}
+
+// inline stylesheets
+foreach ($xpath->query("//link[contains(translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'stylesheet')]") as $link) {
+    /** @var DOMElement $link */
+    $href = trim($link->getAttribute('href'));
+    if ($href === '') { $link->remove(); continue; }
+    $abs = resolve_url($url, $href);
+    if (!$abs) { $link->remove(); continue; }
+    [$css] = fetch_cached($abs);
+    if (!$css) { $link->remove(); continue; }
+    $style = $dom->createElement('style', inline_css_assets($css, $abs));
+    $media = trim($link->getAttribute('media'));
+    if ($media !== '') $style->setAttribute('media', $media);
+    $style->setAttribute('data-inlined', $abs);
+    $link->parentNode->replaceChild($style, $link);
+}
+
+// inline <link rel=preload as=style>
+foreach ($xpath->query("//link[contains(translate(@rel,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'preload')][translate(@as,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz')='style']") as $pre) {
+    /** @var DOMElement $pre */
+    $href = trim($pre->getAttribute('href'));
+    if ($href === '') { $pre->parentNode->removeChild($pre); continue; }
+    $abs = resolve_url($url, $href);
+    if (!$abs) { $pre->parentNode->removeChild($pre); continue; }
+    [$css] = fetch_cached($abs);
+    if ($css) {
+        $style = $dom->createElement('style', inline_css_assets($css, $abs));
+        $media = trim($pre->getAttribute('media'));
+        if ($media !== '') $style->setAttribute('media', $media);
+        $style->setAttribute('data-inlined-preload', $abs);
+        $pre->parentNode->replaceChild($style, $pre);
+    } else {
+        $pre->parentNode->removeChild($pre);
+    }
+}
+
+// inline <img src>
+foreach ($xpath->query("//img[@src]") as $img) {
+    /** @var DOMElement $img */
+    $src = trim($img->getAttribute('src'));
+    if ($src === '' || preg_match('#^(data:|about:|blob:)#i', $src)) continue;
+    $abs = resolve_url($url, $src);
+    if (!$abs) continue;
+    [$bin, $mime] = fetch_cached($abs, true);
+    if (!$bin) continue;
+    $img->setAttribute('src', 'data:' . ($mime ?: 'image/*') . ';base64,' . base64_encode($bin));
+}
+
+// remove scripts
+foreach ($xpath->query("//script") as $s) $s->parentNode->removeChild($s);
+
+echo $dom->saveHTML();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Screenshot Pro — Local Mode</title>
+    <title>Screenshot Pro — Light Mode Demo</title>
     <link rel="stylesheet" href="./static/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
@@ -12,7 +12,8 @@
         <aside id="sidebar" class="sidebar" aria-label="Capture controls">
             <header class="sidebar__header">
                 <h1 class="sidebar__title">Screenshot Pro</h1>
-                <p class="sidebar__subtitle">Local HTML2Canvas capture (slow &amp; experimental).</p>
+                <p class="sidebar__subtitle">Light mode free demo while we build the full release.</p>
+                <p class="sidebar__notice">Email <a href="mailto:screenshotpro@funkpd.com">screenshotpro@funkpd.com</a> if this helps. Pro mode will be $10/month for faster loads, full resolution, and full-size screenshots.</p>
             </header>
             <form id="capture-form" class="stack stack--md" novalidate>
                 <label class="field">
@@ -50,8 +51,10 @@
                 </div>
                 <p class="field__help">Captures happen in your browser. Expect long waits on large pages.</p>
             </section>
-            <footer class="sidebar__footer" aria-live="polite">
-                <p id="sessionStatus" class="sidebar__status" style="white-space: pre-line;">Idle.</p>
+            <footer class="sidebar__footer">
+                <div class="sidebar__log" role="log" aria-live="polite">
+                    <pre id="sessionStatus" class="sidebar__status">Idle.</pre>
+                </div>
             </footer>
         </aside>
         <main class="gallery" aria-live="polite" aria-label="Screenshot gallery">

--- a/index.html
+++ b/index.html
@@ -4,15 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Screenshot Pro — Local Mode</title>
-    <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="stylesheet" href="./static/css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script type="importmap">
-        {
-            "imports": {
-                "app/gallery": "/static/js/gallery.js"
-            }
-        }
-    </script>
 </head>
 <body>
     <div class="app-shell" data-sidebar="expanded">
@@ -71,6 +64,7 @@
             <span id="sidebarToggleLabel" class="sidebar-toggle__label">Hide controls</span>
         </button>
     </div>
-    <script type="module" src="/static/js/local-app.js"></script>
+    <script src="./static/js/gallery.js"></script>
+    <script src="./static/js/local-app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,16 +13,12 @@
             <header class="sidebar__header">
                 <h1 class="sidebar__title">Screenshot Pro</h1>
                 <p class="sidebar__subtitle">Light mode free demo while we build the full release.</p>
-                <p class="sidebar__notice">Email <a href="mailto:screenshotpro@funkpd.com">screenshotpro@funkpd.com</a> if this helps. Pro mode will be $10/month for faster loads, full resolution, and full-size screenshots.</p>
+                <p class="sidebar__notice">Email <a href="mailto:screenshotpro@funkpd.com">screenshotpro@funkpd.com</a> if this helps. Pro mode will be $10/month for faster loads, full resolution, and full-size screenshots, cookie login support & more.</p>
             </header>
             <form id="capture-form" class="stack stack--md" novalidate>
                 <label class="field">
                     <span class="field__label">Page URL</span>
                     <input type="url" id="urlInput" name="url" placeholder="https://example.com" required>
-                </label>
-                <label class="field">
-                    <span class="field__label">Cookie header</span>
-                    <input type="text" id="cookieInput" name="cookie" placeholder="Optional; sent via proxy" disabled>
                 </label>
                 <fieldset class="fieldset">
                     <legend class="field__label">Viewport mode</legend>
@@ -41,12 +37,10 @@
                         </label>
                     </div>
                 </fieldset>
-                <p class="field__help">Proxy: https://testing2.funkpd.shop/cors.php — long timeout to avoid repeat load.</p>
                 <button type="submit" class="button button--primary">Capture page locally</button>
             </form>
             <section class="stack stack--lg" aria-label="Session controls">
                 <div class="cluster">
-                    <button id="newSessionBtn" type="button" class="button">New session</button>
                     <button id="clearGalleryBtn" type="button" class="button">Clear gallery</button>
                 </div>
                 <p class="field__help">Captures happen in your browser. Expect long waits on large pages.</p>

--- a/sitemap-proxy.php
+++ b/sitemap-proxy.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 const TARGET_ENDPOINT = 'https://getsitemap.funkpd.com/json';
-const PAGE_LIMIT = 5;
+const PAGE_LIMIT = 10;
 
 header('Content-Type: application/json; charset=utf-8');
 header('Access-Control-Allow-Origin: *');

--- a/sitemap-proxy.php
+++ b/sitemap-proxy.php
@@ -1,95 +1,84 @@
 <?php
-declare(strict_types=1);
-
 const TARGET_ENDPOINT = 'https://getsitemap.funkpd.com/json';
 const PAGE_LIMIT = 10;
+const MAX_RETRIES = 3;
 
 header('Content-Type: application/json; charset=utf-8');
 header('Access-Control-Allow-Origin: *');
 
-function respond(array $body, int $status = 200): void {
+function respond($data, $status = 200) {
     http_response_code($status);
-    $json = json_encode($body);
-    if ($json === false) {
-        http_response_code(500);
-        echo '{"error":"Failed to encode response."}';
-        exit;
-    }
-    echo $json;
+    echo json_encode($data);
     exit;
 }
 
-$hasUrlParam = array_key_exists('url', $_GET);
-if ($hasUrlParam === false) {
-    respond(['error' => 'Missing query parameter url.'], 400);
-}
+$urlParam = $_GET['url'] ?? '';
+$trimmedUrl = trim($urlParam);
 
-$rawUrl = (string) $_GET['url'];
-$trimmedUrl = trim($rawUrl);
 if ($trimmedUrl === '') {
-    respond(['error' => 'Empty url parameter.'], 400);
+    respond(['error' => 'Missing or empty url parameter.'], 400);
 }
 
-$startsWithHttp = strncasecmp($trimmedUrl, 'http://', 7) === 0;
-if ($startsWithHttp === false) {
-    $startsWithHttps = strncasecmp($trimmedUrl, 'https://', 8) === 0;
-    if ($startsWithHttps === false) {
-        respond(['error' => 'Invalid url scheme; use http or https.'], 400);
+$startsWithHttp = str_starts_with($trimmedUrl, 'http://');
+$startsWithHttps = str_starts_with($trimmedUrl, 'https://');
+
+if ($startsWithHttp === false && $startsWithHttps === false) {
+    respond(['error' => 'Invalid URL scheme. Use http or https.'], 400);
+}
+
+$queryUrl = TARGET_ENDPOINT . '?url=' . rawurlencode($trimmedUrl);
+
+$context = stream_context_create([
+    'http' => [
+        'timeout' => 10,
+        'ignore_errors' => true,
+        'header' => "User-Agent: ScreenshotProProxy/1.0\r\n"
+    ]
+]);
+
+$response = false;
+$delaySeconds = 0.5;
+
+for ($attempt = 1; $attempt <= MAX_RETRIES; $attempt++) {
+    $response = @file_get_contents($queryUrl, false, $context);
+
+    if ($response !== false) {
+        break;
+    }
+
+    if ($attempt < MAX_RETRIES) {
+        usleep((int)($delaySeconds * 1000000));
+        $delaySeconds = $delaySeconds * 2;
     }
 }
 
-$query = TARGET_ENDPOINT . '?url=' . rawurlencode($trimmedUrl);
-$contextOptions = [
-    'http' => [
-        'method' => 'GET',
-        'timeout' => 10,
-        'ignore_errors' => true,
-        'header' => "User-Agent: ScreenshotProProxy/1.0\r\n",
-    ],
-];
-$context = stream_context_create($contextOptions);
-$response = @file_get_contents($query, false, $context);
 if ($response === false) {
-    respond(['error' => 'Failed to fetch sitemap upstream.'], 502);
+    respond(['error' => 'Failed to fetch sitemap after retries.'], 502);
 }
 
-$statusLine = '';
-if (isset($http_response_header[0])) {
-    $statusLine = $http_response_header[0];
-}
-if ($statusLine === '') {
-    respond(['error' => 'Upstream response missing status line.'], 502);
+$json = json_decode($response, true);
+
+if (!is_array($json)) {
+    respond(['error' => 'Invalid JSON from upstream.'], 502);
 }
 
-$statusParts = explode(' ', $statusLine);
-$httpStatus = 0;
-if (count($statusParts) > 1) {
-    $httpStatus = (int) $statusParts[1];
-}
-if ($httpStatus >= 400) {
-    respond(['error' => 'Upstream sitemap request failed.', 'status' => $httpStatus], 502);
+if (!array_key_exists('sitemap', $json)) {
+    respond(['error' => 'Missing sitemap key.'], 502);
 }
 
-$data = json_decode($response, true);
-if (!is_array($data)) {
-    respond(['error' => 'Invalid sitemap payload; expected JSON object.'], 502);
-}
-
-if (!array_key_exists('sitemap', $data)) {
-    respond(['error' => 'Sitemap key missing in payload.'], 502);
-}
-
-if (!is_array($data['sitemap'])) {
-    respond(['error' => 'Sitemap entry is not an array.'], 502);
+if (!is_array($json['sitemap'])) {
+    respond(['error' => 'Sitemap is not an array.'], 502);
 }
 
 $entries = [];
-foreach ($data['sitemap'] as $entry) {
+foreach ($json['sitemap'] as $entry) {
     if (!is_string($entry)) {
         continue;
     }
+
     $entries[] = $entry;
-    if (count($entries) === PAGE_LIMIT) {
+
+    if (count($entries) >= PAGE_LIMIT) {
         break;
     }
 }
@@ -97,5 +86,5 @@ foreach ($data['sitemap'] as $entry) {
 respond([
     'sitemap' => $entries,
     'limit' => PAGE_LIMIT,
-    'sourceCount' => count($data['sitemap']),
+    'sourceCount' => count($json['sitemap'])
 ]);

--- a/sitemap-proxy.php
+++ b/sitemap-proxy.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+
+const TARGET_ENDPOINT = 'https://getsitemap.funkpd.com/json';
+const PAGE_LIMIT = 5;
+
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+
+function respond(array $body, int $status = 200): void {
+    http_response_code($status);
+    $json = json_encode($body);
+    if ($json === false) {
+        http_response_code(500);
+        echo '{"error":"Failed to encode response."}';
+        exit;
+    }
+    echo $json;
+    exit;
+}
+
+$hasUrlParam = array_key_exists('url', $_GET);
+if ($hasUrlParam === false) {
+    respond(['error' => 'Missing query parameter url.'], 400);
+}
+
+$rawUrl = (string) $_GET['url'];
+$trimmedUrl = trim($rawUrl);
+if ($trimmedUrl === '') {
+    respond(['error' => 'Empty url parameter.'], 400);
+}
+
+$startsWithHttp = strncasecmp($trimmedUrl, 'http://', 7) === 0;
+if ($startsWithHttp === false) {
+    $startsWithHttps = strncasecmp($trimmedUrl, 'https://', 8) === 0;
+    if ($startsWithHttps === false) {
+        respond(['error' => 'Invalid url scheme; use http or https.'], 400);
+    }
+}
+
+$query = TARGET_ENDPOINT . '?url=' . rawurlencode($trimmedUrl);
+$contextOptions = [
+    'http' => [
+        'method' => 'GET',
+        'timeout' => 10,
+        'ignore_errors' => true,
+        'header' => "User-Agent: ScreenshotProProxy/1.0\r\n",
+    ],
+];
+$context = stream_context_create($contextOptions);
+$response = @file_get_contents($query, false, $context);
+if ($response === false) {
+    respond(['error' => 'Failed to fetch sitemap upstream.'], 502);
+}
+
+$statusLine = '';
+if (isset($http_response_header[0])) {
+    $statusLine = $http_response_header[0];
+}
+if ($statusLine === '') {
+    respond(['error' => 'Upstream response missing status line.'], 502);
+}
+
+$statusParts = explode(' ', $statusLine);
+$httpStatus = 0;
+if (count($statusParts) > 1) {
+    $httpStatus = (int) $statusParts[1];
+}
+if ($httpStatus >= 400) {
+    respond(['error' => 'Upstream sitemap request failed.', 'status' => $httpStatus], 502);
+}
+
+$data = json_decode($response, true);
+if (!is_array($data)) {
+    respond(['error' => 'Invalid sitemap payload; expected JSON object.'], 502);
+}
+
+if (!array_key_exists('sitemap', $data)) {
+    respond(['error' => 'Sitemap key missing in payload.'], 502);
+}
+
+if (!is_array($data['sitemap'])) {
+    respond(['error' => 'Sitemap entry is not an array.'], 502);
+}
+
+$entries = [];
+foreach ($data['sitemap'] as $entry) {
+    if (!is_string($entry)) {
+        continue;
+    }
+    $entries[] = $entry;
+    if (count($entries) === PAGE_LIMIT) {
+        break;
+    }
+}
+
+respond([
+    'sitemap' => $entries,
+    'limit' => PAGE_LIMIT,
+    'sourceCount' => count($data['sitemap']),
+]);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -118,6 +118,23 @@ body {
     font-size: 0.95rem;
 }
 
+.sidebar__notice {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+.sidebar__notice a {
+    color: var(--color-accent);
+    text-decoration: none;
+}
+
+.sidebar__notice a:hover,
+.sidebar__notice a:focus {
+    text-decoration: underline;
+}
+
 .sidebar__footer {
     margin-top: auto;
     padding-top: var(--gap-md);
@@ -128,6 +145,23 @@ body {
     margin: 0;
     font-size: 0.9rem;
     color: var(--color-muted);
+    font-family: inherit;
+    white-space: pre-line;
+}
+
+.sidebar__log {
+    max-height: 200px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.sidebar__log::-webkit-scrollbar {
+    width: 8px;
+}
+
+.sidebar__log::-webkit-scrollbar-thumb {
+    background: var(--color-ghost);
+    border-radius: 999px;
 }
 
 .gallery {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -33,7 +33,6 @@ body {
     justify-content: stretch;
 }
 
-
 .app-shell {
     position: relative;
     width: 100%;
@@ -275,6 +274,8 @@ body {
 }
 
 .card__actions {
+    position: sticky;
+    bottom: 0;
     display: flex;
     gap: var(--gap-sm);
     padding: var(--gap-sm);
@@ -345,8 +346,10 @@ body {
 
 .fieldset {
     margin: 0;
-    padding: 0;
     border: none;
+    padding: 5px;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    border-radius: var(--radius-md);
 }
 
 .segmented {

--- a/static/js/capture.js
+++ b/static/js/capture.js
@@ -1,3 +1,6 @@
+(function () {
+    'use strict';
+
 const VIEWPORTS = { mobile: 390, tablet: 834, desktop: 1920 };
 const PROXY_ENDPOINT = '/proxy';
 const MAX_CAPTURE_HEIGHT = 12000;
@@ -203,17 +206,33 @@ async function captureSingle(url, options) {
   }
 }
 
-export async function capturePages(options) {
-  if (!options?.urls?.length) throw new Error('No URLs for capture.');
-  const { urls, mode = 'desktop', cookie, onStatus, onCapture } = options;
+async function capturePages(options) {
+  if (!options) throw new Error('No URLs for capture.');
+  if (!Array.isArray(options.urls)) throw new Error('No URLs for capture.');
+  if (options.urls.length === 0) throw new Error('No URLs for capture.');
+
+  const mode = options.mode || 'desktop';
+  const cookie = options.cookie;
+  const onStatus = options.onStatus;
+  const onCapture = options.onCapture;
+  const total = options.urls.length;
   let index = 0;
 
-  for (const url of urls.filter(Boolean)) {
-    index++;
-    notify(onStatus, `Starting ${index}/${urls.length}`);
-    const result = await captureSingle(url.trim(), { mode, cookie, onStatus });
-    if (onCapture) await onCapture(result);
-    notify(onStatus, `Finished ${index}/${urls.length}`);
+  for (const entry of options.urls) {
+    if (!entry) continue;
+    index += 1;
+    notify(onStatus, `Starting ${index}/${total}`);
+    const trimmed = entry.trim();
+    const result = await captureSingle(trimmed, { mode, cookie, onStatus });
+    if (typeof onCapture === 'function') await onCapture(result);
+    notify(onStatus, `Finished ${index}/${total}`);
     await idle();
   }
 }
+
+  const root = window;
+  if (!root.ScreenshotCapture) {
+    root.ScreenshotCapture = {};
+  }
+  root.ScreenshotCapture.capturePages = capturePages;
+})();

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,224 +1,209 @@
-const PLACEHOLDER_TEXT = 'Screenshots will appear here as they finish.';
+(function () {
+    'use strict';
 
-function normalizeModeValue(mode) {
-    if (!mode) return 'desktop';
-    if (typeof mode !== 'string') return 'desktop';
-    const trimmed = mode.trim();
-    if (trimmed === '') return 'desktop';
-    return trimmed;
-}
+    const PLACEHOLDER_TEXT = 'Screenshots will appear here as they finish.';
 
-function formatMode(mode) {
-    if (!mode) return 'Desktop';
-    const lower = mode.toLowerCase();
-    if (lower === 'mobile') return 'Mobile';
-    if (lower === 'tablet') return 'Tablet';
-    if (lower === 'desktop') return 'Desktop';
-    return mode;
-}
-
-function normalizeDimensions(size) {
-    const result = { width: 0, height: 0 };
-    if (!size) return result;
-    const width = Number(size.width);
-    if (Number.isFinite(width)) {
-        result.width = width;
+    function normalizeModeValue(mode) {
+        if (!mode) return 'desktop';
+        if (typeof mode !== 'string') return 'desktop';
+        const trimmed = mode.trim();
+        if (trimmed === '') return 'desktop';
+        return trimmed;
     }
-    const height = Number(size.height);
-    if (Number.isFinite(height)) {
-        result.height = height;
-    }
-    return result;
-}
 
-export function describeImage(image) {
-    if (!image) throw new Error('Missing image payload.');
-    const normalizedMode = normalizeModeValue(image.mode);
-    const meta = {
-        host: '',
-        pageTitle: 'Captured screenshot',
-        pageUrl: '',
-        imageUrl: '',
-        mode: normalizedMode,
-        modeLabel: formatMode(normalizedMode),
-        dimensions: normalizeDimensions(image.dimensions),
-        sourceDimensions: normalizeDimensions(image.sourceDimensions),
-        mime: ''
-    };
-    if (typeof image.host === 'string') {
-        if (image.host !== '') {
-            meta.host = image.host;
+    function formatMode(mode) {
+        if (!mode) return 'Desktop';
+        const lower = mode.toLowerCase();
+        if (lower === 'mobile') return 'Mobile';
+        if (lower === 'tablet') return 'Tablet';
+        if (lower === 'desktop') return 'Desktop';
+        return mode;
+    }
+
+    function normalizeDimensions(size) {
+        const result = { width: 0, height: 0 };
+        if (!size) return result;
+        const width = Number(size.width);
+        if (Number.isFinite(width)) result.width = width;
+        const height = Number(size.height);
+        if (Number.isFinite(height)) result.height = height;
+        return result;
+    }
+
+    function describeImage(image) {
+        if (!image) throw new Error('Missing image payload.');
+        const normalizedMode = normalizeModeValue(image.mode);
+        const meta = {
+            host: '',
+            pageTitle: 'Captured screenshot',
+            pageUrl: '',
+            imageUrl: '',
+            mode: normalizedMode,
+            modeLabel: formatMode(normalizedMode),
+            dimensions: normalizeDimensions(image.dimensions),
+            sourceDimensions: normalizeDimensions(image.sourceDimensions),
+            mime: ''
+        };
+        if (typeof image.host === 'string') {
+            if (image.host !== '') meta.host = image.host;
         }
-    }
-    if (typeof image.pageTitle === 'string') {
-        if (image.pageTitle !== '') {
-            meta.pageTitle = image.pageTitle;
+        if (typeof image.pageTitle === 'string') {
+            if (image.pageTitle !== '') meta.pageTitle = image.pageTitle;
         }
-    }
-    if (typeof image.pageUrl === 'string') {
-        if (image.pageUrl !== '') {
-            meta.pageUrl = image.pageUrl;
+        if (typeof image.pageUrl === 'string') {
+            if (image.pageUrl !== '') meta.pageUrl = image.pageUrl;
         }
-    }
-    if (typeof image.imageUrl === 'string') {
-        if (image.imageUrl !== '') {
-            meta.imageUrl = image.imageUrl;
+        if (typeof image.imageUrl === 'string') {
+            if (image.imageUrl !== '') meta.imageUrl = image.imageUrl;
         }
-    }
-    if (typeof image.mime === 'string') {
-        if (image.mime !== '') {
-            meta.mime = image.mime;
+        if (typeof image.mime === 'string') {
+            if (image.mime !== '') meta.mime = image.mime;
         }
-    }
-    if (meta.imageUrl === '') {
-        throw new Error('Missing image URL; ensure capture stored.');
-    }
-    return meta;
-}
-
-function buildPlaceholder() {
-    const message = document.createElement('p');
-    message.className = 'gallery__placeholder';
-    message.textContent = PLACEHOLDER_TEXT;
-    return message;
-}
-
-function buildLink(href, label) {
-    const link = document.createElement('a');
-    link.href = href;
-    link.textContent = label;
-    link.target = '_blank';
-    link.rel = 'noopener noreferrer';
-    return link;
-}
-
-function applySize(media, size) {
-    if (!size) return;
-    const width = size.width;
-    if (Number.isFinite(width)) media.width = width;
-    const height = size.height;
-    if (Number.isFinite(height)) media.height = height;
-}
-
-function buildImageCard(image) {
-    let meta;
-    try {
-        meta = describeImage(image);
-    } catch (error) {
-        console.error(error);
-        return null;
-    }
-    const card = document.createElement('article');
-    card.className = 'card';
-
-    const header = document.createElement('header');
-    header.className = 'card__meta';
-    let hasHeader = false;
-    if (meta.host !== '') {
-        const title = document.createElement('p');
-        title.className = 'card__title';
-        title.textContent = meta.host;
-        header.appendChild(title);
-        hasHeader = true;
-    }
-    if (meta.modeLabel !== '') {
-        const badge = document.createElement('span');
-        badge.className = 'card__badge';
-        badge.textContent = meta.modeLabel;
-        header.appendChild(badge);
-        hasHeader = true;
-    }
-    if (hasHeader) {
-        card.appendChild(header);
+        if (meta.imageUrl === '') throw new Error('Missing image URL; ensure capture stored.');
+        return meta;
     }
 
-    const media = document.createElement('img');
-    media.className = 'card__media';
-    media.loading = 'lazy';
-    media.decoding = 'async';
-    media.fetchPriority = 'low';
-    media.alt = meta.pageTitle;
-    applySize(media, meta.dimensions);
-    media.src = meta.imageUrl;
-    if (meta.mime !== '') {
-        media.dataset.mime = meta.mime;
-    }
-    const source = meta.sourceDimensions;
-    if (source.width > 0) {
-        media.dataset.sourceWidth = String(source.width);
-    }
-    if (source.height > 0) {
-        media.dataset.sourceHeight = String(source.height);
+    function buildPlaceholder() {
+        const message = document.createElement('p');
+        message.className = 'gallery__placeholder';
+        message.textContent = PLACEHOLDER_TEXT;
+        return message;
     }
 
-    const actions = document.createElement('div');
-    actions.className = 'card__actions';
-    if (meta.pageUrl !== '') {
-        actions.appendChild(buildLink(meta.pageUrl, 'View page'));
-    }
-    actions.appendChild(buildLink(meta.imageUrl, 'View image'));
-
-    card.appendChild(media);
-    card.appendChild(actions);
-    return card;
-}
-
-function buildErrorCard(image) {
-    const card = document.createElement('article');
-    card.className = 'card';
-
-    const message = document.createElement('div');
-    message.className = 'card__actions';
-    let prefix = 'Capture failed';
-    if (image.mode) {
-        const modeLabel = formatMode(image.mode);
-        prefix = `Capture failed (${modeLabel})`;
-    }
-    message.textContent = `${prefix}: ${image.error}`;
-
-    card.appendChild(message);
-    return card;
-}
-
-export function createGallery(container) {
-    if (!container) throw new Error('Missing gallery container.');
-
-    let empty = true;
-
-    function showPlaceholder() {
-        container.dataset.empty = '';
-        container.innerHTML = '';
-        container.appendChild(buildPlaceholder());
-        empty = true;
+    function buildLink(href, label) {
+        const link = document.createElement('a');
+        link.href = href;
+        link.textContent = label;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        return link;
     }
 
-    function ensureContent() {
-        if (!empty) return;
-        container.removeAttribute('data-empty');
-        container.innerHTML = '';
-        empty = false;
+    function applySize(media, size) {
+        if (!size) return;
+        const width = size.width;
+        if (Number.isFinite(width)) media.width = width;
+        const height = size.height;
+        if (Number.isFinite(height)) media.height = height;
     }
 
-    function append(image) {
-        if (!image) return;
-        ensureContent();
-        if (image.status === 'error') {
-            const errorCard = buildErrorCard(image);
-            container.appendChild(errorCard);
-            return;
+    function buildImageCard(image) {
+        let meta;
+        try {
+            meta = describeImage(image);
+        } catch (error) {
+            console.error(error);
+            return null;
         }
-        const card = buildImageCard(image);
-        if (!card) return;
-        const batch = document.createDocumentFragment();
-        batch.appendChild(card);
-        container.appendChild(batch);
+        const card = document.createElement('article');
+        card.className = 'card';
+
+        const header = document.createElement('header');
+        header.className = 'card__meta';
+        let hasHeader = false;
+        if (meta.host !== '') {
+            const title = document.createElement('p');
+            title.className = 'card__title';
+            title.textContent = meta.host;
+            header.appendChild(title);
+            hasHeader = true;
+        }
+        if (meta.modeLabel !== '') {
+            const badge = document.createElement('span');
+            badge.className = 'card__badge';
+            badge.textContent = meta.modeLabel;
+            header.appendChild(badge);
+            hasHeader = true;
+        }
+        if (hasHeader) card.appendChild(header);
+
+        const media = document.createElement('img');
+        media.className = 'card__media';
+        media.loading = 'lazy';
+        media.decoding = 'async';
+        media.fetchPriority = 'low';
+        media.alt = meta.pageTitle;
+        applySize(media, meta.dimensions);
+        media.src = meta.imageUrl;
+        if (meta.mime !== '') media.dataset.mime = meta.mime;
+        const source = meta.sourceDimensions;
+        if (source.width > 0) media.dataset.sourceWidth = String(source.width);
+        if (source.height > 0) media.dataset.sourceHeight = String(source.height);
+
+        const actions = document.createElement('div');
+        actions.className = 'card__actions';
+        if (meta.pageUrl !== '') actions.appendChild(buildLink(meta.pageUrl, 'View page'));
+        actions.appendChild(buildLink(meta.imageUrl, 'View image'));
+
+        card.appendChild(media);
+        card.appendChild(actions);
+        return card;
     }
 
-    function clear() {
+    function buildErrorCard(image) {
+        const card = document.createElement('article');
+        card.className = 'card';
+
+        const message = document.createElement('div');
+        message.className = 'card__actions';
+        let prefix = 'Capture failed';
+        if (image.mode) {
+            const modeLabel = formatMode(image.mode);
+            prefix = `Capture failed (${modeLabel})`;
+        }
+        message.textContent = `${prefix}: ${image.error}`;
+
+        card.appendChild(message);
+        return card;
+    }
+
+    function createGallery(container) {
+        if (!container) throw new Error('Missing gallery container.');
+
+        let empty = true;
+
+        function showPlaceholder() {
+            container.dataset.empty = '';
+            container.innerHTML = '';
+            container.appendChild(buildPlaceholder());
+            empty = true;
+        }
+
+        function ensureContent() {
+            if (!empty) return;
+            container.removeAttribute('data-empty');
+            container.innerHTML = '';
+            empty = false;
+        }
+
+        function append(image) {
+            if (!image) return;
+            ensureContent();
+            if (image.status === 'error') {
+                const errorCard = buildErrorCard(image);
+                container.appendChild(errorCard);
+                return;
+            }
+            const card = buildImageCard(image);
+            if (!card) return;
+            const batch = document.createDocumentFragment();
+            batch.appendChild(card);
+            container.appendChild(batch);
+        }
+
+        function clear() {
+            showPlaceholder();
+        }
+
         showPlaceholder();
+
+        return { append, clear };
     }
 
-    showPlaceholder();
-
-    return { append, clear };
-}
+    const root = window;
+    if (!root.ScreenshotGallery) {
+        root.ScreenshotGallery = {};
+    }
+    root.ScreenshotGallery.describeImage = describeImage;
+    root.ScreenshotGallery.createGallery = createGallery;
+})();

--- a/static/js/local-app.js
+++ b/static/js/local-app.js
@@ -1,389 +1,354 @@
-(function () {
-    'use strict';
+'use strict';
 
-    if (!window.ScreenshotGallery) {
-        throw new Error('Missing ScreenshotGallery; load gallery.js before local-app.js.');
+// assumes window.ScreenshotGallery.createGallery and window.html2canvas are loaded
+const createGallery = window.ScreenshotGallery.createGallery;
+
+const PROXY_ENDPOINT = 'https://testing2.funkpd.shop/cors.php';
+const SITEMAP_ENDPOINT = './sitemap-proxy.php';
+const SITEMAP_PAGE_LIMIT = 10;
+const MAX_CAPTURE_HEIGHT = 6000;
+const PREVIEW_SCALE = 0.25;
+const EXPORT_MIME = 'image/webp';
+const EXPORT_QUALITY = 0.7;
+
+const VIEWPORTS = { mobile: 390, tablet: 834, desktop: 1920 };
+const blobUrls = new Set();
+
+function selectById(elementId) {
+    const element = document.getElementById(elementId);
+    if (!element) throw new Error(`#${elementId} missing`);
+    return element;
+}
+
+function writeStatus(statusElement, message) {
+    if (!statusElement) return;
+    statusElement.textContent = message;
+    statusElement.scrollTop = statusElement.scrollHeight;
+}
+
+function appendStatus(statusElement, message) {
+    if (!statusElement) return;
+    statusElement.textContent += `\n${message}`;
+    statusElement.scrollTop = statusElement.scrollHeight;
+}
+
+function deriveHost(urlString) {
+    if (!urlString) return '';
+    const parsedUrl = new URL(urlString);
+    return parsedUrl.hostname;
+}
+
+function resolveViewportWidth(mode) {
+    const width = VIEWPORTS[mode];
+    if (width) return width;
+    return VIEWPORTS.desktop;
+}
+
+function disableForm(formElement, isDisabled) {
+    const controls = Array.from(formElement.elements);
+    for (const controlElement of controls) {
+        controlElement.disabled = isDisabled;
     }
-    if (typeof window.ScreenshotGallery.createGallery !== 'function') {
-        throw new Error('Missing ScreenshotGallery.createGallery; load gallery.js before local-app.js.');
+}
+
+function createProxyUrl(targetUrl) {
+    const encoded = encodeURIComponent(targetUrl);
+    return `${PROXY_ENDPOINT}?url=${encoded}`;
+}
+
+async function fetchSnapshot(targetUrl) {
+    const proxyUrl = createProxyUrl(targetUrl);
+    const response = await fetch(proxyUrl);
+    if (!response.ok) throw new Error(`Proxy fetch failed (${response.status})`);
+    const htmlText = await response.text();
+    return htmlText;
+}
+
+function getVisualZoom() {
+    const hasViewport = !!(window.visualViewport && typeof window.visualViewport.scale === 'number');
+    if (!hasViewport) return 1;
+    return window.visualViewport.scale || 1;
+}
+
+function cssWidthForTrue1920() {
+    const zoomScale = getVisualZoom();
+    if (zoomScale === 0) return 1920;
+    const cssWidth = Math.round(1920 / zoomScale);
+    return cssWidth;
+}
+
+function buildIframe(targetCssWidth) {
+    const iframeElement = document.createElement('iframe');
+    iframeElement.style.width = `${targetCssWidth}px`;
+    iframeElement.style.height = '100px';
+    iframeElement.style.visibility = 'hidden';
+    iframeElement.style.display = 'block';
+    iframeElement.style.border = '0';
+    iframeElement.style.position = 'absolute';
+    iframeElement.style.left = '0';
+    iframeElement.style.top = '0';
+    iframeElement.style.pointerEvents = 'none';
+    iframeElement.setAttribute('width', String(targetCssWidth));
+    iframeElement.setAttribute('height', '100');
+    document.body.appendChild(iframeElement);
+    return iframeElement;
+}
+
+function removeIframe(iframeElement) {
+    if (!iframeElement) return;
+    if (!iframeElement.parentNode) return;
+    iframeElement.parentNode.removeChild(iframeElement);
+}
+
+function writeHtmlIntoFrame(iframeElement, htmlText) {
+    const frameDocument = iframeElement.contentDocument;
+    if (!frameDocument) throw new Error('Missing frame document');
+    frameDocument.open();
+    frameDocument.write(htmlText);
+    frameDocument.close();
+    return frameDocument;
+}
+
+function freezeAnimations(frameDocument) {
+    const styleElement = frameDocument.createElement('style');
+    styleElement.textContent = '*,*::before,*::after{animation:none!important;transition:none!important}';
+    const headElement = frameDocument.head || frameDocument.documentElement;
+    headElement.appendChild(styleElement);
+}
+
+function forceFixedCssWidth(frameDocument, targetCssWidth) {
+    const headElement = frameDocument.head || frameDocument.documentElement;
+    const normalizeStyle = frameDocument.createElement('style');
+    normalizeStyle.textContent =
+        'html,body{margin:0;padding:0;overflow:visible!important;}' +
+        `html{width:${targetCssWidth}px!important;max-width:none!important;min-width:0!important;}`;
+    headElement.appendChild(normalizeStyle);
+}
+
+function computeCaptureBox(frameDocument) {
+    const htmlElement = frameDocument.documentElement;
+    const bodyElement = frameDocument.body;
+
+    let widthHtml = 0;
+    let widthBody = 0;
+    let heightHtml = 0;
+    let heightBody = 0;
+
+    if (htmlElement) widthHtml = htmlElement.scrollWidth;
+    if (bodyElement) widthBody = bodyElement.scrollWidth;
+    if (htmlElement) heightHtml = htmlElement.scrollHeight;
+    if (bodyElement) heightBody = bodyElement.scrollHeight;
+
+    const cssWidth = Math.max(widthHtml, widthBody);
+    const rawHeight = Math.max(heightHtml, heightBody);
+    const cssHeight = rawHeight > MAX_CAPTURE_HEIGHT ? MAX_CAPTURE_HEIGHT : rawHeight;
+
+    return { cssWidth, cssHeight };
+}
+
+async function renderPage(frameDocument, forcedCssWidth) {
+    const html2canvasFactory = window.html2canvas;
+
+    const box = computeCaptureBox(frameDocument);
+    const cssWidth = box.cssWidth || forcedCssWidth;
+    const cssHeight = box.cssHeight;
+
+    const options = {
+        backgroundColor: '#fff',
+        useCORS: true,
+        width: cssWidth,
+        height: cssHeight,
+        windowWidth: cssWidth,
+        windowHeight: cssHeight,
+        scrollX: 0,
+        scrollY: 0,
+        scale: 1,
+        foreignObjectRendering: true
+    };
+
+    const baseCanvas = await html2canvasFactory(frameDocument.documentElement, options);
+
+    const previewCanvas = document.createElement('canvas');
+    previewCanvas.width = Math.round(baseCanvas.width * PREVIEW_SCALE);
+    previewCanvas.height = Math.round(baseCanvas.height * PREVIEW_SCALE);
+
+    const drawingContext = previewCanvas.getContext('2d');
+    drawingContext.imageSmoothingEnabled = true;
+    drawingContext.imageSmoothingQuality = 'high';
+    drawingContext.drawImage(baseCanvas, 0, 0, previewCanvas.width, previewCanvas.height);
+
+    baseCanvas.width = 0;
+    baseCanvas.height = 0;
+    return previewCanvas;
+}
+
+function exportCanvasBlob(canvasElement) {
+    return new Promise((resolve, reject) => {
+        canvasElement.toBlob(blobObject => {
+            if (!blobObject) reject(new Error('Canvas export failed'));
+            if (blobObject) resolve(blobObject);
+        }, EXPORT_MIME, EXPORT_QUALITY);
+    });
+}
+
+function releaseBlobUrls() {
+    for (const blobUrl of blobUrls) {
+        URL.revokeObjectURL(blobUrl);
     }
+    blobUrls.clear();
+}
 
-    const createGallery = window.ScreenshotGallery.createGallery;
+function enforceZoom(statusEl) {
+    const ratio = window.devicePixelRatio || 1;
+    const percent = Math.round(ratio * 100);
 
-    const PROXY_ENDPOINT = 'https://testing2.funkpd.shop/cors.php';
-    const SITEMAP_ENDPOINT = './sitemap-proxy.php';
-    const SITEMAP_PAGE_LIMIT = 5;
-    const FETCH_COOLDOWN_MS = 5000;
-    const MAX_CAPTURE_HEIGHT = 6000;
-    const PREVIEW_SCALE = 0.25;
-    const EXPORT_MIME = 'image/webp';
-    const EXPORT_QUALITY = 0.7;
-
-    const VIEWPORTS = { mobile: 390, tablet: 834, desktop: 1920 };
-    const blobUrls = new Set();
-    let nextFetchReadyAt = 0;
-
-    function selectById(id) {
-        const el = document.getElementById(id);
-        if (!el) throw new Error(`#${id} missing`);
-        return el;
-    }
-
-    function writeStatus(target, msg) {
-        if (!target) return;
-        target.textContent = msg;
-        target.scrollTop = target.scrollHeight;
-    }
-
-    function appendStatus(target, msg, data) {
-        if (!target) return;
-        const stamp = new Date().toISOString();
-        const line = `[${stamp}] ${msg}`;
-        if (data) {
-            console.log(line, data);
+    if (ratio !== 1) {
+        if (statusEl) {
+            statusEl.textContent = `⚠️ Zoom is ${percent}%. Set browser zoom to 100% before capture.`;
+            statusEl.scrollTop = statusEl.scrollHeight;
         } else {
-            console.log(line);
+            alert(`⚠️ Zoom is ${percent}%. Set browser zoom to 100% before capture.`);
         }
-        target.textContent += `\n${line}`;
-        target.scrollTop = target.scrollHeight;
+        throw new Error(`Zoom ${percent}% not allowed`);
     }
+}
 
-    function deriveHost(url) {
-        if (!url) return '';
-        const parsed = new URL(url);
-        return parsed.hostname;
-    }
 
-    function resolveViewportWidth(mode) {
-        const width = VIEWPORTS[mode];
-        if (width) return width;
-        return VIEWPORTS.desktop;
-    }
+async function capturePage(params) {
+    enforceZoom(params.statusElement);
+    appendStatus(params.statusElement, `→ Capture ${params.url} (${params.mode})`);
+    const htmlText = await fetchSnapshot(params.url);
 
-    function disableForm(form, disabled) {
-        const controls = Array.from(form.elements);
-        controls.forEach(control => {
-            control.disabled = disabled;
+    const targetCssWidth = cssWidthForTrue1920();
+    const iframeElement = buildIframe(targetCssWidth);
+
+    try {
+        const frameDocument = writeHtmlIntoFrame(iframeElement, htmlText);
+
+        // hard-lock layout width irrespective of outer-page zoom
+        forceFixedCssWidth(frameDocument, targetCssWidth);
+        freezeAnimations(frameDocument);
+
+        // allow layout to settle at the forced width
+        await new Promise(resolve => requestAnimationFrame(resolve));
+
+        const previewCanvas = await renderPage(frameDocument, targetCssWidth);
+        const blobObject = await exportCanvasBlob(previewCanvas);
+        const blobUrl = URL.createObjectURL(blobObject);
+        blobUrls.add(blobUrl);
+
+        params.gallery.append({
+            host: deriveHost(params.url),
+            mode: params.mode,
+            pageUrl: params.url,
+            imageUrl: blobUrl,
+            blob: blobObject,
+            dimensions: { width: previewCanvas.width, height: previewCanvas.height },
+            mime: blobObject.type
         });
-    }
 
-    function createProxyUrl(url) {
-        const encoded = encodeURIComponent(url);
-        return `${PROXY_ENDPOINT}?url=${encoded}`;
+        previewCanvas.width = 0;
+        previewCanvas.height = 0;
+        appendStatus(params.statusElement, '✓ Done');
+    } finally {
+        removeIframe(iframeElement);
     }
+}
 
-    function wait(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
+async function fetchSitemapUrls(baseUrl, statusElement) {
+    const endpointUrl = `${SITEMAP_ENDPOINT}?url=${encodeURIComponent(baseUrl)}`;
+    const response = await fetch(endpointUrl);
+    if (!response.ok) throw new Error(`Sitemap fetch failed (${response.status})`);
+    const payload = await response.json();
+    let list = [];
+    if (Array.isArray(payload.sitemap)) list = payload.sitemap;
+    if (list.length === 0) throw new Error('Empty sitemap');
+    if (list.length > SITEMAP_PAGE_LIMIT) list = list.slice(0, SITEMAP_PAGE_LIMIT);
+    appendStatus(statusElement, `✓ Sitemap ${list.length} url(s)`);
+    return list;
+}
+
+function parseUrlInput(rawInput) {
+    const trimmed = rawInput.trim();
+    if (trimmed === '') return [];
+    const parts = trimmed.split(/\s+/);
+    const unique = new Set();
+    for (const part of parts) {
+        const isHttp = /^https?:\/\//i.test(part);
+        if (isHttp) unique.add(part);
     }
+    return Array.from(unique);
+}
 
-    function raf() {
-        return new Promise(resolve => requestAnimationFrame(resolve));
-    }
-
-    async function waitForNextFetchSlot(statusEl) {
-        const now = Date.now();
-        if (now >= nextFetchReadyAt) return;
-        const waitMs = nextFetchReadyAt - now;
-        appendStatus(statusEl, `→ Waiting ${waitMs}ms`);
-        await wait(waitMs);
-    }
-
-    async function fetchSnapshot(url, statusEl) {
-        await waitForNextFetchSlot(statusEl);
-        const proxyUrl = createProxyUrl(url);
-        appendStatus(statusEl, '→ Fetching snapshot', { proxyUrl });
-        const res = await fetch(proxyUrl);
-        if (!res.ok) throw new Error(`Proxy fetch failed (${res.status})`);
-        const html = await res.text();
-        appendStatus(statusEl, '✓ HTML bytes', { length: html.length });
-        return html;
-    }
-
-    function buildIframe(width) {
-        const frame = document.createElement('iframe');
-        Object.assign(frame.style, {
-            width: `${width}px`,
-            height: '100px',
-            visibility: 'hidden',
-            display: 'block',
-            border: '0',
-            position: 'absolute',
-            left: '-10000px',
-            top: '0',
-            pointerEvents: 'none'
-        });
-        document.body.appendChild(frame);
-        return frame;
-    }
-
-    function removeIframe(frame) {
-        if (!frame) return;
-        if (!frame.parentNode) return;
-        frame.parentNode.removeChild(frame);
-    }
-
-    function writeHtmlIntoFrame(frame, html) {
-        const primary = frame.contentDocument;
-        if (primary) {
-            primary.open();
-            primary.write(html);
-            primary.close();
-            return primary;
-        }
-        const fallbackWindow = frame.contentWindow;
-        if (!fallbackWindow) throw new Error('Missing frame window; cannot write HTML.');
-        const fallbackDoc = fallbackWindow.document;
-        if (!fallbackDoc) throw new Error('Missing frame document; cannot write HTML.');
-        fallbackDoc.open();
-        fallbackDoc.write(html);
-        fallbackDoc.close();
-        return fallbackDoc;
-    }
-
-    function freezeAnimations(doc) {
-        const style = doc.createElement('style');
-        style.textContent = '*,*::before,*::after{animation:none!important;transition:none!important}';
-        const head = doc.head || doc.documentElement;
-        head.appendChild(style);
-    }
-
-    async function settleFonts(doc, statusEl) {
-        const fonts = doc.fonts;
-        if (!fonts) {
-            appendStatus(statusEl, '✓ Fonts skipped');
-            return;
-        }
-        const ready = fonts.ready;
-        if (!ready) {
-            appendStatus(statusEl, '✓ Fonts skipped');
-            return;
-        }
-        await ready;
-        appendStatus(statusEl, '✓ Fonts ready');
-    }
-
-    function computePageHeight(doc) {
-        const root = doc.documentElement;
-        const body = doc.body;
-        const heights = [];
-        if (root) heights.push(root.scrollHeight, root.offsetHeight);
-        if (body) heights.push(body.scrollHeight);
-        heights.push(MAX_CAPTURE_HEIGHT);
-        return Math.max(...heights);
-    }
-
-    function clampHeight(value) {
-        if (!value) return MAX_CAPTURE_HEIGHT;
-        if (value > MAX_CAPTURE_HEIGHT) return MAX_CAPTURE_HEIGHT;
-        return value;
-    }
-
-    function ensureHtml2Canvas() {
-        if (typeof window.html2canvas !== 'function') {
-            throw new Error('Missing html2canvas; include script before local-app.js.');
-        }
-        return window.html2canvas;
-    }
-
-    async function renderPage(doc, width, height, statusEl) {
-        const html2canvas = ensureHtml2Canvas();
-        const options = {
-            backgroundColor: '#fff',
-            useCORS: true,
-            width,
-            height,
-            windowWidth: width,
-            windowHeight: height,
-            scale: 1,
-            foreignObjectRendering: true
-        };
-        appendStatus(statusEl, '→ Rendering', { width, height });
-        const canvas = await html2canvas(doc.documentElement, options);
-        const scaled = document.createElement('canvas');
-        scaled.width = Math.round(canvas.width * PREVIEW_SCALE);
-        scaled.height = Math.round(canvas.height * PREVIEW_SCALE);
-        const ctx = scaled.getContext('2d');
-        ctx.imageSmoothingEnabled = true;
-        ctx.imageSmoothingQuality = 'high';
-        ctx.drawImage(canvas, 0, 0, scaled.width, scaled.height);
-        canvas.width = 0;
-        canvas.height = 0;
-        return scaled;
-    }
-
-    async function exportCanvasBlob(canvas) {
-        return new Promise((resolve, reject) => {
-            canvas.toBlob(blob => {
-                if (!blob) {
-                    reject(new Error('Canvas export failed; blob missing.'));
-                    return;
-                }
-                resolve(blob);
-            }, EXPORT_MIME, EXPORT_QUALITY);
-        });
-    }
-
-    function createBlobUrl(blob) {
-        return URL.createObjectURL(blob);
-    }
-
-    function releaseBlobUrls() {
-        blobUrls.forEach(url => {
-            URL.revokeObjectURL(url);
-        });
-        blobUrls.clear();
-    }
-
-    function scheduleFetchCooldown(statusEl) {
-        nextFetchReadyAt = Date.now() + FETCH_COOLDOWN_MS;
-        appendStatus(statusEl, `→ Cooling down ${FETCH_COOLDOWN_MS}ms`);
-    }
-
-    async function capturePage(params) {
-        appendStatus(params.statusEl, '→ Capture', { url: params.url, mode: params.mode });
-        const html = await fetchSnapshot(params.url, params.statusEl);
-        const frame = buildIframe(params.width);
-        try {
-            const doc = writeHtmlIntoFrame(frame, html);
-            freezeAnimations(doc);
-            await raf();
-            await raf();
-            await settleFonts(doc, params.statusEl);
-            const rawHeight = computePageHeight(doc);
-            const captureHeight = clampHeight(rawHeight);
-            const canvas = await renderPage(doc, params.width, captureHeight, params.statusEl);
-            const blob = await exportCanvasBlob(canvas);
-            const blobUrl = createBlobUrl(blob);
-            blobUrls.add(blobUrl);
-            params.gallery.append({
-                host: deriveHost(params.url),
-                mode: params.mode,
-                pageUrl: params.url,
-                imageUrl: blobUrl,
-                blob,
-                dimensions: { width: canvas.width, height: canvas.height },
-                mime: blob.type
-            });
-            canvas.width = 0;
-            canvas.height = 0;
-            appendStatus(params.statusEl, '✓ Done', { url: params.url });
-            if (params.hasNext) scheduleFetchCooldown(params.statusEl);
-        } finally {
-            removeIframe(frame);
+async function collectSitemapUrls(rawInput, statusElement) {
+    const baseUrls = parseUrlInput(rawInput);
+    const collected = [];
+    for (const baseUrl of baseUrls) {
+        if (collected.length >= SITEMAP_PAGE_LIMIT) break;
+        const entries = await fetchSitemapUrls(baseUrl, statusElement);
+        for (const entryUrl of entries) {
+            const isHttp = /^https?:\/\//i.test(entryUrl);
+            if (!isHttp) continue;
+            collected.push(entryUrl);
+            if (collected.length >= SITEMAP_PAGE_LIMIT) break;
         }
     }
+    appendStatus(statusElement, `✓ Collected ${collected.length} url(s)`);
+    return collected;
+}
 
-    async function fetchSitemapUrls(baseUrl, statusEl) {
-        const endpoint = `${SITEMAP_ENDPOINT}?url=${encodeURIComponent(baseUrl)}`;
-        const res = await fetch(endpoint);
-        if (!res.ok) throw new Error(`Sitemap fetch failed (${res.status})`);
-        const data = await res.json();
-        let list = [];
-        if (Array.isArray(data.sitemap)) {
-            list = data.sitemap;
-        }
-        if (!list.length) throw new Error('Empty sitemap');
-        if (list.length > SITEMAP_PAGE_LIMIT) {
-            list = list.slice(0, SITEMAP_PAGE_LIMIT);
-        }
-        let upstreamCount = list.length;
-        if (typeof data.sourceCount === 'number') {
-            upstreamCount = data.sourceCount;
-        }
-        let enforcedLimit = SITEMAP_PAGE_LIMIT;
-        if (typeof data.limit === 'number') {
-            enforcedLimit = data.limit;
-        }
-        appendStatus(statusEl, '✓ Sitemap loaded', { count: list.length, source: upstreamCount, limit: enforcedLimit });
-        return list;
+function resolveSelectedMode(modeNodeList) {
+    const inputs = Array.from(modeNodeList);
+    for (const inputElement of inputs) {
+        if (inputElement.checked) return inputElement.value;
     }
+    return 'desktop';
+}
 
-    function parseUrlInput(raw) {
-        const trimmed = raw.trim();
-        if (trimmed === '') return [];
-        const parts = trimmed.split(/\s+/);
-        const unique = new Set();
-        parts.forEach(url => {
-            if (/^https?:\/\//i.test(url)) unique.add(url);
-        });
-        return Array.from(unique);
+async function handleCapture(formElement, urlInputElement, modeNodeList, statusElement, galleryApi) {
+    disableForm(formElement, true);
+    writeStatus(statusElement, '');
+    const urls = await collectSitemapUrls(urlInputElement.value, statusElement);
+    const mode = resolveSelectedMode(modeNodeList);
+    const width = resolveViewportWidth(mode);
+    for (let index = 0; index < urls.length; index += 1) {
+        await capturePage({ url: urls[index], mode, width, statusElement, gallery: galleryApi });
     }
+    disableForm(formElement, false);
+}
 
-    async function collectSitemapUrls(raw, statusEl) {
-        const bases = parseUrlInput(raw);
-        const urls = [];
-        for (const base of bases) {
-            if (urls.length >= SITEMAP_PAGE_LIMIT) {
-                break;
-            }
-            const entries = await fetchSitemapUrls(base, statusEl);
-            for (const entry of entries) {
-                if (!/^https?:\/\//i.test(entry)) {
-                    continue;
-                }
-                urls.push(entry);
-                if (urls.length >= SITEMAP_PAGE_LIMIT) {
-                    break;
-                }
-            }
-        }
-        appendStatus(statusEl, '✓ URLs collected', { total: urls.length, max: SITEMAP_PAGE_LIMIT });
-        return urls;
+function init() {
+    const formElement = selectById('capture-form');
+    const urlInputElement = selectById('urlInput');
+    const statusElement = selectById('sessionStatus');
+    const galleryContainer = selectById('result');
+    const clearGalleryButton = selectById('clearGalleryBtn');
+    const modeNodeList = document.querySelectorAll('input[name="mode"]');
+    const galleryApi = createGallery(galleryContainer);
+
+    writeStatus(statusElement, `Idle. Ready. Max ${SITEMAP_PAGE_LIMIT} pages per session.`);
+
+    clearGalleryButton.onclick = () => {
+        releaseBlobUrls();
+        galleryApi.clear();
+        writeStatus(statusElement, 'Gallery cleared.');
+    };
+
+    formElement.onsubmit = async eventObject => {
+        eventObject.preventDefault();
+        await handleCapture(formElement, urlInputElement, modeNodeList, statusElement, galleryApi);
+    };
+}
+
+window.addEventListener('beforeunload', releaseBlobUrls);
+
+function boot() {
+    const isLoading = document.readyState === 'loading';
+    if (isLoading) {
+        document.addEventListener('DOMContentLoaded', init);
+        return;
     }
+    init();
+}
 
-    function resolveSelectedMode(modeInputs) {
-        const list = Array.from(modeInputs);
-        for (const input of list) {
-            if (input.checked) return input.value;
-        }
-        return 'desktop';
-    }
-
-    async function handleCapture(form, urlInput, modeInputs, statusEl, gallery) {
-        disableForm(form, true);
-        writeStatus(statusEl, '');
-        const urls = await collectSitemapUrls(urlInput.value, statusEl);
-        const mode = resolveSelectedMode(modeInputs);
-        const width = resolveViewportWidth(mode);
-        for (let i = 0; i < urls.length; i += 1) {
-            const hasNext = i < urls.length - 1;
-            await capturePage({ url: urls[i], mode, width, statusEl, gallery, hasNext });
-        }
-        disableForm(form, false);
-    }
-
-    function init() {
-        const form = selectById('capture-form');
-        const urlInput = selectById('urlInput');
-        const statusEl = selectById('sessionStatus');
-        const galleryContainer = selectById('result');
-        const clearGalleryBtn = selectById('clearGalleryBtn');
-        const modeInputs = document.querySelectorAll('input[name="mode"]');
-        const gallery = createGallery(galleryContainer);
-
-        writeStatus(statusEl, 'Idle. Ready. Max 5 pages per session.');
-
-        clearGalleryBtn.onclick = () => {
-            releaseBlobUrls();
-            gallery.clear();
-            writeStatus(statusEl, 'Gallery cleared.');
-        };
-
-        form.onsubmit = async event => {
-            event.preventDefault();
-            await handleCapture(form, urlInput, modeInputs, statusEl, gallery);
-        };
-    }
-
-    window.addEventListener('beforeunload', releaseBlobUrls);
-
-    function boot() {
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', init);
-            return;
-        }
-        init();
-    }
-
-    boot();
-})();
+boot();

--- a/static/js/local-app.js
+++ b/static/js/local-app.js
@@ -1,269 +1,372 @@
-import { createGallery } from 'app/gallery';
+(function () {
+    'use strict';
 
-const PROXY_ENDPOINT = 'https://testing2.funkpd.shop/cors.php';
-const SITEMAP_ENDPOINT = 'https://getsitemap.funkpd.com/json';
-const FETCH_COOLDOWN_MS = 5000;
-const IMAGE_TIMEOUT_MS = 5000;
-const MAX_CAPTURE_HEIGHT = 6000;
-const PREVIEW_SCALE = 0.25;
-const EXPORT_MIME = 'image/webp';
-const EXPORT_QUALITY = 0.7;
+    if (!window.ScreenshotGallery) {
+        throw new Error('Missing ScreenshotGallery; load gallery.js before local-app.js.');
+    }
+    if (typeof window.ScreenshotGallery.createGallery !== 'function') {
+        throw new Error('Missing ScreenshotGallery.createGallery; load gallery.js before local-app.js.');
+    }
 
-const VIEWPORTS = { mobile: 390, tablet: 834, desktop: 1920 };
-const blobUrls = new Set();
-let nextFetchReadyAt = 0;
+    const createGallery = window.ScreenshotGallery.createGallery;
 
-const selectById = id => {
-  const el = document.getElementById(id);
-  if (!el) throw new Error(`#${id} missing`);
-  return el;
-};
+    const PROXY_ENDPOINT = 'https://testing2.funkpd.shop/cors.php';
+    const SITEMAP_ENDPOINT = 'https://getsitemap.funkpd.com/json';
+    const FETCH_COOLDOWN_MS = 5000;
+    const MAX_CAPTURE_HEIGHT = 6000;
+    const PREVIEW_SCALE = 0.25;
+    const EXPORT_MIME = 'image/webp';
+    const EXPORT_QUALITY = 0.7;
 
-const writeStatus = (target, msg) => {
-  if (!target) return;
-  target.textContent = msg;
-  target.scrollTop = target.scrollHeight;
-};
+    const VIEWPORTS = { mobile: 390, tablet: 834, desktop: 1920 };
+    const blobUrls = new Set();
+    let nextFetchReadyAt = 0;
 
-const appendStatus = (target, msg, data) => {
-  if (!target) return;
-  const stamp = new Date().toISOString();
-  const line = `[${stamp}] ${msg}`;
-  console.log(line, data || '');
-  target.textContent += `\n${line}`;
-  target.scrollTop = target.scrollHeight;
-};
+    function selectById(id) {
+        const el = document.getElementById(id);
+        if (!el) throw new Error(`#${id} missing`);
+        return el;
+    }
 
-const deriveHost = url => (url ? new URL(url).hostname : '');
-const resolveViewportWidth = mode => VIEWPORTS[mode] || VIEWPORTS.desktop;
+    function writeStatus(target, msg) {
+        if (!target) return;
+        target.textContent = msg;
+        target.scrollTop = target.scrollHeight;
+    }
 
-const disableForm = (form, disabled) => {
-  Array.from(form.elements || []).forEach(c => (c.disabled = disabled));
-};
+    function appendStatus(target, msg, data) {
+        if (!target) return;
+        const stamp = new Date().toISOString();
+        const line = `[${stamp}] ${msg}`;
+        if (data) {
+            console.log(line, data);
+        } else {
+            console.log(line);
+        }
+        target.textContent += `\n${line}`;
+        target.scrollTop = target.scrollHeight;
+    }
 
-const createProxyUrl = url => `${PROXY_ENDPOINT}?url=${encodeURIComponent(url)}`;
-const wait = ms => new Promise(r => setTimeout(r, ms));
-const raf = () => new Promise(r => requestAnimationFrame(r));
+    function deriveHost(url) {
+        if (!url) return '';
+        const parsed = new URL(url);
+        return parsed.hostname;
+    }
 
-async function waitForNextFetchSlot(statusEl) {
-  const now = Date.now();
-  if (now < nextFetchReadyAt) {
-    const waitMs = nextFetchReadyAt - now;
-    appendStatus(statusEl, `→ Waiting ${waitMs}ms`);
-    await wait(waitMs);
-  }
-}
+    function resolveViewportWidth(mode) {
+        const width = VIEWPORTS[mode];
+        if (width) return width;
+        return VIEWPORTS.desktop;
+    }
 
-async function fetchSnapshot(url, statusEl) {
-  await waitForNextFetchSlot(statusEl);
-  const proxyUrl = createProxyUrl(url);
-  appendStatus(statusEl, '→ Fetching snapshot', { proxyUrl });
-  const res = await fetch(proxyUrl);
-  if (!res.ok) throw new Error(`Proxy fetch failed (${res.status})`);
-  const html = await res.text();
-  appendStatus(statusEl, '✓ HTML bytes', { length: html.length });
-  return html;
-}
+    function disableForm(form, disabled) {
+        const controls = Array.from(form.elements);
+        controls.forEach(control => {
+            control.disabled = disabled;
+        });
+    }
 
-function buildIframe(width) {
-  const frame = document.createElement('iframe');
-  Object.assign(frame.style, {
-    width: `${width}px`,
-    height: '100px',
-    visibility: 'hidden',
-    display: 'block',
-    border: '0',
-    position: 'absolute',
-    left: '-10000px',
-    top: '0',
-    pointerEvents: 'none'
-  });
-  document.body.appendChild(frame);
-  return frame;
-}
+    function createProxyUrl(url) {
+        const encoded = encodeURIComponent(url);
+        return `${PROXY_ENDPOINT}?url=${encoded}`;
+    }
 
-const removeIframe = frame => frame?.parentNode?.removeChild(frame);
+    function wait(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
 
-const writeHtmlIntoFrame = (frame, html) => {
-  const doc = frame.contentDocument || frame.contentWindow.document;
-  doc.open();
-  doc.write(html);
-  doc.close();
-  return doc;
-};
+    function raf() {
+        return new Promise(resolve => requestAnimationFrame(resolve));
+    }
 
-const freezeAnimations = doc => {
-  const style = doc.createElement('style');
-  style.textContent = `*,*::before,*::after{animation:none!important;transition:none!important}`;
-  (doc.head || doc.documentElement).appendChild(style);
-};
+    async function waitForNextFetchSlot(statusEl) {
+        const now = Date.now();
+        if (now >= nextFetchReadyAt) return;
+        const waitMs = nextFetchReadyAt - now;
+        appendStatus(statusEl, `→ Waiting ${waitMs}ms`);
+        await wait(waitMs);
+    }
 
-async function settleFonts(doc, statusEl) {
-  if (doc.fonts?.ready) await doc.fonts.ready;
-  appendStatus(statusEl, '✓ Fonts ready');
-}
+    async function fetchSnapshot(url, statusEl) {
+        await waitForNextFetchSlot(statusEl);
+        const proxyUrl = createProxyUrl(url);
+        appendStatus(statusEl, '→ Fetching snapshot', { proxyUrl });
+        const res = await fetch(proxyUrl);
+        if (!res.ok) throw new Error(`Proxy fetch failed (${res.status})`);
+        const html = await res.text();
+        appendStatus(statusEl, '✓ HTML bytes', { length: html.length });
+        return html;
+    }
 
-function computePageHeight(doc) {
-  const root = doc.documentElement;
-  const body = doc.body;
-  return Math.max(
-    root.scrollHeight,
-    root.offsetHeight,
-    body?.scrollHeight || 0,
-    MAX_CAPTURE_HEIGHT
-  );
-}
+    function buildIframe(width) {
+        const frame = document.createElement('iframe');
+        Object.assign(frame.style, {
+            width: `${width}px`,
+            height: '100px',
+            visibility: 'hidden',
+            display: 'block',
+            border: '0',
+            position: 'absolute',
+            left: '-10000px',
+            top: '0',
+            pointerEvents: 'none'
+        });
+        document.body.appendChild(frame);
+        return frame;
+    }
 
-const clampHeight = h => Math.min(h || MAX_CAPTURE_HEIGHT, MAX_CAPTURE_HEIGHT);
+    function removeIframe(frame) {
+        if (!frame) return;
+        if (!frame.parentNode) return;
+        frame.parentNode.removeChild(frame);
+    }
 
-const ensureHtml2Canvas = () => window.html2canvas;
+    function writeHtmlIntoFrame(frame, html) {
+        const primary = frame.contentDocument;
+        if (primary) {
+            primary.open();
+            primary.write(html);
+            primary.close();
+            return primary;
+        }
+        const fallbackWindow = frame.contentWindow;
+        if (!fallbackWindow) throw new Error('Missing frame window; cannot write HTML.');
+        const fallbackDoc = fallbackWindow.document;
+        if (!fallbackDoc) throw new Error('Missing frame document; cannot write HTML.');
+        fallbackDoc.open();
+        fallbackDoc.write(html);
+        fallbackDoc.close();
+        return fallbackDoc;
+    }
 
-async function renderPage(doc, width, height, statusEl) {
-  const html2canvas = ensureHtml2Canvas();
-  const options = {
-    backgroundColor: '#fff',
-    useCORS: true,
-    width,
-    height,
-    windowWidth: width,
-    windowHeight: height,
-    scale: 1
-  };
-  appendStatus(statusEl, '→ Rendering', { width, height });
-  const canvas = await html2canvas(doc.documentElement, { ...options, foreignObjectRendering: true });
-  const scaled = document.createElement('canvas');
-  scaled.width = Math.round(canvas.width * PREVIEW_SCALE);
-  scaled.height = Math.round(canvas.height * PREVIEW_SCALE);
-  const ctx = scaled.getContext('2d');
-  ctx.imageSmoothingEnabled = true;
-  ctx.imageSmoothingQuality = 'high';
-  ctx.drawImage(canvas, 0, 0, scaled.width, scaled.height);
-  canvas.width = canvas.height = 0;
+    function freezeAnimations(doc) {
+        const style = doc.createElement('style');
+        style.textContent = '*,*::before,*::after{animation:none!important;transition:none!important}';
+        const head = doc.head || doc.documentElement;
+        head.appendChild(style);
+    }
 
-  return scaled;
-}
+    async function settleFonts(doc, statusEl) {
+        const fonts = doc.fonts;
+        if (!fonts) {
+            appendStatus(statusEl, '✓ Fonts skipped');
+            return;
+        }
+        const ready = fonts.ready;
+        if (!ready) {
+            appendStatus(statusEl, '✓ Fonts skipped');
+            return;
+        }
+        await ready;
+        appendStatus(statusEl, '✓ Fonts ready');
+    }
 
-async function exportCanvasBlob(canvas) {
-  return new Promise((resolve, reject) =>
-    canvas.toBlob(b => (b ? resolve(b) : reject()), EXPORT_MIME, EXPORT_QUALITY)
-  );
-}
+    function computePageHeight(doc) {
+        const root = doc.documentElement;
+        const body = doc.body;
+        const heights = [];
+        if (root) heights.push(root.scrollHeight, root.offsetHeight);
+        if (body) heights.push(body.scrollHeight);
+        heights.push(MAX_CAPTURE_HEIGHT);
+        return Math.max(...heights);
+    }
 
-const createBlobUrl = blob => URL.createObjectURL(blob);
+    function clampHeight(value) {
+        if (!value) return MAX_CAPTURE_HEIGHT;
+        if (value > MAX_CAPTURE_HEIGHT) return MAX_CAPTURE_HEIGHT;
+        return value;
+    }
 
-const releaseBlobUrls = () => {
-  blobUrls.forEach(url => URL.revokeObjectURL(url));
-  blobUrls.clear();
-};
+    function ensureHtml2Canvas() {
+        if (typeof window.html2canvas !== 'function') {
+            throw new Error('Missing html2canvas; include script before local-app.js.');
+        }
+        return window.html2canvas;
+    }
 
-const scheduleFetchCooldown = statusEl => {
-  nextFetchReadyAt = Date.now() + FETCH_COOLDOWN_MS;
-  appendStatus(statusEl, `→ Cooling down ${FETCH_COOLDOWN_MS}ms`);
-};
+    async function renderPage(doc, width, height, statusEl) {
+        const html2canvas = ensureHtml2Canvas();
+        const options = {
+            backgroundColor: '#fff',
+            useCORS: true,
+            width,
+            height,
+            windowWidth: width,
+            windowHeight: height,
+            scale: 1,
+            foreignObjectRendering: true
+        };
+        appendStatus(statusEl, '→ Rendering', { width, height });
+        const canvas = await html2canvas(doc.documentElement, options);
+        const scaled = document.createElement('canvas');
+        scaled.width = Math.round(canvas.width * PREVIEW_SCALE);
+        scaled.height = Math.round(canvas.height * PREVIEW_SCALE);
+        const ctx = scaled.getContext('2d');
+        ctx.imageSmoothingEnabled = true;
+        ctx.imageSmoothingQuality = 'high';
+        ctx.drawImage(canvas, 0, 0, scaled.width, scaled.height);
+        canvas.width = 0;
+        canvas.height = 0;
+        return scaled;
+    }
 
-async function capturePage({ url, mode, width, statusEl, gallery, hasNext }) {
-  appendStatus(statusEl, '→ Capture', { url, mode });
-  const html = await fetchSnapshot(url, statusEl);
-  const frame = buildIframe(width);
-  try {
-    const doc = writeHtmlIntoFrame(frame, html);
-    freezeAnimations(doc);
-    await raf(); await raf();
-    await settleFonts(doc, statusEl);
-    const rawHeight = computePageHeight(doc);
-    const captureHeight = clampHeight(rawHeight);
-    const canvas = await renderPage(doc, width, captureHeight, statusEl);
-    const blob = await exportCanvasBlob(canvas);
-    const blobUrl = createBlobUrl(blob);
-    blobUrls.add(blobUrl);
-    gallery.append({
-      host: deriveHost(url),
-      mode,
-      pageUrl: url,
-      imageUrl: blobUrl,
-      blob,
-      dimensions: { width: canvas.width, height: canvas.height },
-      mime: blob.type
-    });
-    canvas.width = canvas.height = 0;
-    appendStatus(statusEl, '✓ Done', { url });
-    if (hasNext) scheduleFetchCooldown(statusEl);
-  } finally {
-    removeIframe(frame);
-  }
-}
+    async function exportCanvasBlob(canvas) {
+        return new Promise((resolve, reject) => {
+            canvas.toBlob(blob => {
+                if (!blob) {
+                    reject(new Error('Canvas export failed; blob missing.'));
+                    return;
+                }
+                resolve(blob);
+            }, EXPORT_MIME, EXPORT_QUALITY);
+        });
+    }
 
-async function fetchSitemapUrls(baseUrl, statusEl) {
-  const endpoint = `${SITEMAP_ENDPOINT}?url=${encodeURIComponent(baseUrl)}`;
-  const res = await fetch(endpoint);
-  if (!res.ok) throw new Error(`Sitemap fetch failed (${res.status})`);
-  const data = await res.json();
-  const list = Array.isArray(data.sitemap) ? data.sitemap : [];
-  if (!list.length) throw new Error('Empty sitemap');
-  appendStatus(statusEl, '✓ Sitemap loaded', { count: list.length });
-  return list;
-}
+    function createBlobUrl(blob) {
+        return URL.createObjectURL(blob);
+    }
 
-function parseUrlInput(raw) {
-  const urls = raw.trim().split(/\s+/);
-  return [...new Set(urls.filter(u => /^https?:\/\//i.test(u)))];
-}
+    function releaseBlobUrls() {
+        blobUrls.forEach(url => {
+            URL.revokeObjectURL(url);
+        });
+        blobUrls.clear();
+    }
 
-async function collectSitemapUrls(raw, statusEl) {
-  const bases = parseUrlInput(raw);
-  const urls = [];
-  for (const base of bases) {
-    const entries = await fetchSitemapUrls(base, statusEl);
-    urls.push(...entries.filter(u => /^https?:\/\//i.test(u)));
-  }
-  appendStatus(statusEl, '✓ URLs collected', { total: urls.length });
-  return urls;
-}
+    function scheduleFetchCooldown(statusEl) {
+        nextFetchReadyAt = Date.now() + FETCH_COOLDOWN_MS;
+        appendStatus(statusEl, `→ Cooling down ${FETCH_COOLDOWN_MS}ms`);
+    }
 
-async function handleCapture(form, urlInput, modeInputs, statusEl, gallery) {
-  disableForm(form, true);
-  writeStatus(statusEl, '');
-  const urls = await collectSitemapUrls(urlInput.value, statusEl);
-  const mode = Array.from(modeInputs).find(r => r.checked)?.value || 'desktop';
-  const width = resolveViewportWidth(mode);
-  for (let i = 0; i < urls.length; i++) {
-    const hasNext = i < urls.length - 1;
-    await capturePage({ url: urls[i], mode, width, statusEl, gallery, hasNext });
-  }
-  disableForm(form, false);
-}
+    async function capturePage(params) {
+        appendStatus(params.statusEl, '→ Capture', { url: params.url, mode: params.mode });
+        const html = await fetchSnapshot(params.url, params.statusEl);
+        const frame = buildIframe(params.width);
+        try {
+            const doc = writeHtmlIntoFrame(frame, html);
+            freezeAnimations(doc);
+            await raf();
+            await raf();
+            await settleFonts(doc, params.statusEl);
+            const rawHeight = computePageHeight(doc);
+            const captureHeight = clampHeight(rawHeight);
+            const canvas = await renderPage(doc, params.width, captureHeight, params.statusEl);
+            const blob = await exportCanvasBlob(canvas);
+            const blobUrl = createBlobUrl(blob);
+            blobUrls.add(blobUrl);
+            params.gallery.append({
+                host: deriveHost(params.url),
+                mode: params.mode,
+                pageUrl: params.url,
+                imageUrl: blobUrl,
+                blob,
+                dimensions: { width: canvas.width, height: canvas.height },
+                mime: blob.type
+            });
+            canvas.width = 0;
+            canvas.height = 0;
+            appendStatus(params.statusEl, '✓ Done', { url: params.url });
+            if (params.hasNext) scheduleFetchCooldown(params.statusEl);
+        } finally {
+            removeIframe(frame);
+        }
+    }
 
-function init() {
-  const form = selectById('capture-form');
-  const urlInput = selectById('urlInput');
-  const statusEl = selectById('sessionStatus');
-  const galleryContainer = selectById('result');
-  const newSessionBtn = selectById('newSessionBtn');
-  const clearGalleryBtn = selectById('clearGalleryBtn');
-  const modeInputs = document.querySelectorAll('input[name="mode"]');
-  const gallery = createGallery(galleryContainer);
+    async function fetchSitemapUrls(baseUrl, statusEl) {
+        const endpoint = `${SITEMAP_ENDPOINT}?url=${encodeURIComponent(baseUrl)}`;
+        const res = await fetch(endpoint);
+        if (!res.ok) throw new Error(`Sitemap fetch failed (${res.status})`);
+        const data = await res.json();
+        const list = Array.isArray(data.sitemap) ? data.sitemap : [];
+        if (!list.length) throw new Error('Empty sitemap');
+        appendStatus(statusEl, '✓ Sitemap loaded', { count: list.length });
+        return list;
+    }
 
-  writeStatus(statusEl, 'Idle. Ready.');
+    function parseUrlInput(raw) {
+        const trimmed = raw.trim();
+        if (trimmed === '') return [];
+        const parts = trimmed.split(/\s+/);
+        const unique = new Set();
+        parts.forEach(url => {
+            if (/^https?:\/\//i.test(url)) unique.add(url);
+        });
+        return Array.from(unique);
+    }
 
-  newSessionBtn.onclick = () => {
-    releaseBlobUrls();
-    gallery.clear();
-    writeStatus(statusEl, 'Session reset.');
-  };
+    async function collectSitemapUrls(raw, statusEl) {
+        const bases = parseUrlInput(raw);
+        const urls = [];
+        for (const base of bases) {
+            const entries = await fetchSitemapUrls(base, statusEl);
+            entries.forEach(entry => {
+                if (/^https?:\/\//i.test(entry)) urls.push(entry);
+            });
+        }
+        appendStatus(statusEl, '✓ URLs collected', { total: urls.length });
+        return urls;
+    }
 
-  clearGalleryBtn.onclick = () => {
-    releaseBlobUrls();
-    gallery.clear();
-    writeStatus(statusEl, 'Gallery cleared.');
-  };
+    function resolveSelectedMode(modeInputs) {
+        const list = Array.from(modeInputs);
+        for (const input of list) {
+            if (input.checked) return input.value;
+        }
+        return 'desktop';
+    }
 
-  form.onsubmit = async e => {
-    e.preventDefault();
-    await handleCapture(form, urlInput, modeInputs, statusEl, gallery);
-  };
-}
+    async function handleCapture(form, urlInput, modeInputs, statusEl, gallery) {
+        disableForm(form, true);
+        writeStatus(statusEl, '');
+        const urls = await collectSitemapUrls(urlInput.value, statusEl);
+        const mode = resolveSelectedMode(modeInputs);
+        const width = resolveViewportWidth(mode);
+        for (let i = 0; i < urls.length; i += 1) {
+            const hasNext = i < urls.length - 1;
+            await capturePage({ url: urls[i], mode, width, statusEl, gallery, hasNext });
+        }
+        disableForm(form, false);
+    }
 
-window.addEventListener('beforeunload', releaseBlobUrls);
-document.readyState === 'loading'
-  ? document.addEventListener('DOMContentLoaded', init)
-  : init();
+    function init() {
+        const form = selectById('capture-form');
+        const urlInput = selectById('urlInput');
+        const statusEl = selectById('sessionStatus');
+        const galleryContainer = selectById('result');
+        const newSessionBtn = selectById('newSessionBtn');
+        const clearGalleryBtn = selectById('clearGalleryBtn');
+        const modeInputs = document.querySelectorAll('input[name="mode"]');
+        const gallery = createGallery(galleryContainer);
+
+        writeStatus(statusEl, 'Idle. Ready.');
+
+        newSessionBtn.onclick = () => {
+            releaseBlobUrls();
+            gallery.clear();
+            writeStatus(statusEl, 'Session reset.');
+        };
+
+        clearGalleryBtn.onclick = () => {
+            releaseBlobUrls();
+            gallery.clear();
+            writeStatus(statusEl, 'Gallery cleared.');
+        };
+
+        form.onsubmit = async event => {
+            event.preventDefault();
+            await handleCapture(form, urlInput, modeInputs, statusEl, gallery);
+        };
+    }
+
+    window.addEventListener('beforeunload', releaseBlobUrls);
+
+    function boot() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+            return;
+        }
+        init();
+    }
+
+    boot();
+})();

--- a/static/js/local-app.js
+++ b/static/js/local-app.js
@@ -357,18 +357,11 @@
         const urlInput = selectById('urlInput');
         const statusEl = selectById('sessionStatus');
         const galleryContainer = selectById('result');
-        const newSessionBtn = selectById('newSessionBtn');
         const clearGalleryBtn = selectById('clearGalleryBtn');
         const modeInputs = document.querySelectorAll('input[name="mode"]');
         const gallery = createGallery(galleryContainer);
 
         writeStatus(statusEl, 'Idle. Ready. Max 5 pages per session.');
-
-        newSessionBtn.onclick = () => {
-            releaseBlobUrls();
-            gallery.clear();
-            writeStatus(statusEl, 'Session reset.');
-        };
 
         clearGalleryBtn.onclick = () => {
             releaseBlobUrls();

--- a/static/js/sidebar.js
+++ b/static/js/sidebar.js
@@ -1,0 +1,41 @@
+function setSidebarState(appShell, sidebar, toggleBtn, labelEl, iconEl, nextState) {
+    appShell.dataset.sidebar = nextState;
+    const expanded = nextState === 'expanded';
+
+    toggleBtn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    sidebar.setAttribute('aria-hidden', expanded ? 'false' : 'true');
+
+    if (labelEl) {
+        labelEl.textContent = expanded ? 'Hide controls' : 'Show controls';
+    }
+
+    if (iconEl) {
+        iconEl.textContent = expanded ? '⟨' : '⟩';
+    }
+}
+
+function initSidebar(appShell, sidebar, toggleBtn, labelEl, iconEl) {
+    let initial = appShell.dataset.sidebar || 'expanded';
+
+    if (typeof window.matchMedia === 'function') {
+        const query = window.matchMedia('(max-width: 960px)');
+        if (query && query.matches) {
+            initial = 'collapsed';
+        }
+    }
+
+    setSidebarState(appShell, sidebar, toggleBtn, labelEl, iconEl, initial);
+
+    toggleBtn.addEventListener('click', () => {
+        const current = appShell.dataset.sidebar;
+        const next = current === 'collapsed' ? 'expanded' : 'collapsed';
+        setSidebarState(appShell, sidebar, toggleBtn, labelEl, iconEl, next);
+    });
+}
+initSidebar(
+    document.querySelector('.app-shell'),
+    document.getElementById('sidebar'),
+    document.getElementById('sidebarToggle'),
+    document.getElementById('sidebarToggleLabel'),
+    document.getElementById('sidebarToggleIcon')
+);


### PR DESCRIPTION
## Summary
- move the local capture UI to the project root as `index.html` and update script includes to plain `<script>` tags
- rewrite the gallery and local capture code to use vanilla scripts attached to `window` instead of ES modules/import maps
- wrap the proxy capture helper in a browser IIFE so it exposes a global API without `export`

## Testing
- not run (per instructions)

------
https://chatgpt.com/codex/tasks/task_e_68f9dc65445c8325a26f76298c73d111