### PR TITLE
Make zoom warning dismissible

### DIFF
--- a/static/js/enforce-zoom.js
+++ b/static/js/enforce-zoom.js
@@ -1,4 +1,6 @@
 const ZOOM_WARNING_MODAL_ID = 'zoom-warning-modal';
+const ZOOM_WARNING_TEXT_ID = 'zoom-warning-text';
+const ZOOM_WARNING_DISMISS_ID = 'zoom-warning-dismiss';
 const CHECK_INTERVAL_MS = 500;
 const EXPECTED_ZOOM_PERCENT = 100;
 const MODAL_STYLE_PROPERTIES = {
@@ -17,6 +19,7 @@ const MODAL_STYLE_PROPERTIES = {
     display: 'none',
     boxShadow: '0 4px 12px rgba(0,0,0,0.4)'
 };
+let dismissedZoomPercent = null;
 function enforceZoomWatcher() {
     let zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     if (!zoomWarningModal) {
@@ -31,6 +34,22 @@ function createZoomWarningModal() {
     const modalElement = document.createElement('div');
     modalElement.id = ZOOM_WARNING_MODAL_ID;
     Object.assign(modalElement.style, MODAL_STYLE_PROPERTIES);
+    const messageElement = document.createElement('div');
+    messageElement.id = ZOOM_WARNING_TEXT_ID;
+    messageElement.style.marginBottom = '12px';
+    modalElement.appendChild(messageElement);
+    const dismissButton = document.createElement('button');
+    dismissButton.type = 'button';
+    dismissButton.id = ZOOM_WARNING_DISMISS_ID;
+    dismissButton.textContent = 'Dismiss';
+    dismissButton.style.background = '#fff';
+    dismissButton.style.color = '#d90000';
+    dismissButton.style.border = 'none';
+    dismissButton.style.borderRadius = '4px';
+    dismissButton.style.padding = '8px 16px';
+    dismissButton.style.cursor = 'pointer';
+    dismissButton.addEventListener('click', handleDismissClick);
+    modalElement.appendChild(dismissButton);
     return modalElement;
 }
 function getZoomPercent() {
@@ -48,24 +67,42 @@ function getZoomPercent() {
 }
 function checkZoomLevel() {
     const currentZoom = getZoomPercent();
-    if (currentZoom !== EXPECTED_ZOOM_PERCENT) {
-        setWarningMessage(currentZoom);
-        showModal();
-    } else {
+    const isExpectedZoom = currentZoom === EXPECTED_ZOOM_PERCENT;
+    if (isExpectedZoom) {
+        resetDismissedZoom();
         hideModal();
+        return;
     }
+    const isDismissedZoom = dismissedZoomPercent === currentZoom;
+    if (isDismissedZoom) {
+        return;
+    }
+    setWarningMessage(currentZoom);
+    showModal();
 }
 function setWarningMessage(zoomValue) {
     const warningText = `⚠️ Browser zoom is ${zoomValue}%. Set zoom to 100% for accurate captures.`;
-    const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
-    zoomWarningModal.textContent = warningText;
+    const warningMessage = document.getElementById(ZOOM_WARNING_TEXT_ID);
+    if (!warningMessage) {
+        return;
+    }
+    warningMessage.textContent = warningText;
 }
 function showModal() {
+    dismissedZoomPercent = null;
     const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     zoomWarningModal.style.display = 'block';
 }
 function hideModal() {
     const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     zoomWarningModal.style.display = 'none';
+}
+function handleDismissClick() {
+    const currentZoom = getZoomPercent();
+    dismissedZoomPercent = currentZoom;
+    hideModal();
+}
+function resetDismissedZoom() {
+    dismissedZoomPercent = null;
 }
 enforceZoomWatcher();


### PR DESCRIPTION
## Summary
- add a dismiss control to the zoom warning modal so users can capture while zoom is off
- track the dismissed zoom level and restore the warning only after the zoom value changes or returns to 100%
- ensure the modal message updates without blocking the Capture Site Locally button once dismissed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690307d5cc1483259d900d4b53bb3d30