### PR TITLE
Add zoom reset action to zoom warning modal

### DIFF
--- a/static/js/capture-core.js
+++ b/static/js/capture-core.js
@@ -29,15 +29,9 @@ function appendStatus(target, message) {
     target.scrollTop = target.scrollHeight;
 }
 
-function getVisualZoom() {
-    const hasVisualViewport = !!(window.visualViewport && typeof window.visualViewport.scale === 'number');
-    if (!hasVisualViewport) return 1;
-    return window.visualViewport.scale || 1;
-}
-
 function cssWidthForTrue1920(baseWidth = 1920) {
-    const zoom = getVisualZoom();
-    return zoom === 0 ? baseWidth : Math.round(baseWidth / zoom);
+    if (!baseWidth) return 1920;
+    return baseWidth;
 }
 
 function buildIframe(targetCssWidth) {

--- a/static/js/enforce-zoom.js
+++ b/static/js/enforce-zoom.js
@@ -4,6 +4,7 @@ const ZOOM_WARNING_DISMISS_ID = 'zoom-warning-dismiss';
 const ZOOM_WARNING_SET_ID = 'zoom-warning-set';
 const CHECK_INTERVAL_MS = 500;
 const EXPECTED_ZOOM_PERCENT = 100;
+const GLOBAL_ZOOM_CORRECTION_KEY = '__SCREENSHOT_ENFORCED_ZOOM_RATIO__';
 const MODAL_STYLE_PROPERTIES = {
     position: 'fixed',
     top: '50%',
@@ -145,6 +146,7 @@ function applyZoomCorrection(currentZoom) {
         bodyElement.style.zoom = `${zoomRatio}`;
     }
     correctedZoomRatio = zoomRatio;
+    publishZoomCorrection();
 }
 function clearZoomCorrection() {
     const htmlElement = document.documentElement;
@@ -160,8 +162,13 @@ function clearZoomCorrection() {
         bodyElement.style.zoom = '';
     }
     correctedZoomRatio = null;
+    publishZoomCorrection();
 }
 function resetDismissedZoom() {
     dismissedZoomPercent = null;
 }
+function publishZoomCorrection() {
+    window[GLOBAL_ZOOM_CORRECTION_KEY] = correctedZoomRatio;
+}
+publishZoomCorrection();
 enforceZoomWatcher();

--- a/static/js/enforce-zoom.js
+++ b/static/js/enforce-zoom.js
@@ -100,7 +100,7 @@ function checkZoomLevel() {
     showModal();
 }
 function setWarningMessage(zoomValue) {
-    const warningText = `⚠️ Browser zoom is ${zoomValue}%. Set zoom to 100% for accurate captures.`;
+    const warningText = `⚠️ Browser zoom is ${zoomValue}%. Set zoom to 100% for accurate captures. This is a desktop app, we can't support mobile use at this time. Expect broken layouts if you're using a mobile device, or not at 100% zoom.`;
     const warningMessage = document.getElementById(ZOOM_WARNING_TEXT_ID);
     if (!warningMessage) {
         return;

--- a/static/js/enforce-zoom.js
+++ b/static/js/enforce-zoom.js
@@ -1,4 +1,7 @@
 const ZOOM_WARNING_MODAL_ID = 'zoom-warning-modal';
+const ZOOM_WARNING_TEXT_ID = 'zoom-warning-text';
+const ZOOM_WARNING_DISMISS_ID = 'zoom-warning-dismiss';
+const ZOOM_WARNING_SET_ID = 'zoom-warning-set';
 const CHECK_INTERVAL_MS = 500;
 const EXPECTED_ZOOM_PERCENT = 100;
 const MODAL_STYLE_PROPERTIES = {
@@ -17,6 +20,16 @@ const MODAL_STYLE_PROPERTIES = {
     display: 'none',
     boxShadow: '0 4px 12px rgba(0,0,0,0.4)'
 };
+const BUTTON_STYLE_PROPERTIES = {
+    background: '#fff',
+    color: '#d90000',
+    border: 'none',
+    borderRadius: '4px',
+    padding: '8px 16px',
+    cursor: 'pointer'
+};
+let dismissedZoomPercent = null;
+let correctedZoomRatio = null;
 function enforceZoomWatcher() {
     let zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     if (!zoomWarningModal) {
@@ -31,7 +44,30 @@ function createZoomWarningModal() {
     const modalElement = document.createElement('div');
     modalElement.id = ZOOM_WARNING_MODAL_ID;
     Object.assign(modalElement.style, MODAL_STYLE_PROPERTIES);
+    const messageElement = document.createElement('div');
+    messageElement.id = ZOOM_WARNING_TEXT_ID;
+    messageElement.style.marginBottom = '12px';
+    modalElement.appendChild(messageElement);
+    const actionsContainer = document.createElement('div');
+    actionsContainer.style.display = 'flex';
+    actionsContainer.style.gap = '8px';
+    actionsContainer.style.justifyContent = 'center';
+    const setButton = createModalButton(ZOOM_WARNING_SET_ID, 'Set zoom to 100%');
+    setButton.addEventListener('click', handleSetZoomClick);
+    actionsContainer.appendChild(setButton);
+    const dismissButton = createModalButton(ZOOM_WARNING_DISMISS_ID, 'Dismiss');
+    dismissButton.addEventListener('click', handleDismissClick);
+    actionsContainer.appendChild(dismissButton);
+    modalElement.appendChild(actionsContainer);
     return modalElement;
+}
+function createModalButton(id, text) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.id = id;
+    button.textContent = text;
+    Object.assign(button.style, BUTTON_STYLE_PROPERTIES);
+    return button;
 }
 function getZoomPercent() {
     const devicePixelRatio = window.devicePixelRatio;
@@ -48,24 +84,84 @@ function getZoomPercent() {
 }
 function checkZoomLevel() {
     const currentZoom = getZoomPercent();
-    if (currentZoom !== EXPECTED_ZOOM_PERCENT) {
-        setWarningMessage(currentZoom);
-        showModal();
-    } else {
+    const isExpectedZoom = currentZoom === EXPECTED_ZOOM_PERCENT;
+    if (isExpectedZoom) {
+        clearZoomCorrection();
+        resetDismissedZoom();
         hideModal();
+        return;
     }
+    const isDismissedZoom = dismissedZoomPercent === currentZoom;
+    if (isDismissedZoom) {
+        return;
+    }
+    setWarningMessage(currentZoom);
+    showModal();
 }
 function setWarningMessage(zoomValue) {
     const warningText = `⚠️ Browser zoom is ${zoomValue}%. Set zoom to 100% for accurate captures.`;
-    const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
-    zoomWarningModal.textContent = warningText;
+    const warningMessage = document.getElementById(ZOOM_WARNING_TEXT_ID);
+    if (!warningMessage) {
+        return;
+    }
+    warningMessage.textContent = warningText;
 }
 function showModal() {
+    dismissedZoomPercent = null;
     const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     zoomWarningModal.style.display = 'block';
 }
 function hideModal() {
     const zoomWarningModal = document.getElementById(ZOOM_WARNING_MODAL_ID);
     zoomWarningModal.style.display = 'none';
+}
+function handleDismissClick() {
+    const currentZoom = getZoomPercent();
+    dismissedZoomPercent = currentZoom;
+    hideModal();
+}
+function handleSetZoomClick() {
+    const currentZoom = getZoomPercent();
+    applyZoomCorrection(currentZoom);
+    dismissedZoomPercent = currentZoom;
+    hideModal();
+}
+function applyZoomCorrection(currentZoom) {
+    const htmlElement = document.documentElement;
+    if (!htmlElement) {
+        return;
+    }
+    if (currentZoom === 0) {
+        return;
+    }
+    if (currentZoom === EXPECTED_ZOOM_PERCENT) {
+        clearZoomCorrection();
+        return;
+    }
+    const zoomRatio = EXPECTED_ZOOM_PERCENT / currentZoom;
+    htmlElement.style.zoom = `${zoomRatio}`;
+    const bodyElement = document.body;
+    if (bodyElement) {
+        bodyElement.style.zoom = `${zoomRatio}`;
+    }
+    correctedZoomRatio = zoomRatio;
+}
+function clearZoomCorrection() {
+    const htmlElement = document.documentElement;
+    if (!htmlElement) {
+        return;
+    }
+    if (correctedZoomRatio === null) {
+        return;
+    }
+    htmlElement.style.zoom = '';
+    const bodyElement = document.body;
+    if (bodyElement) {
+        bodyElement.style.zoom = '';
+    }
+    correctedZoomRatio = null;
+}
+function resetDismissedZoom() {
+    dismissedZoomPercent = null;
 }
 enforceZoomWatcher();

--- a/static/js/frame-tools.js
+++ b/static/js/frame-tools.js
@@ -1,21 +1,8 @@
-function getVisualZoom() {
-    const hasVisualViewport = !!(window.visualViewport && typeof window.visualViewport.scale === 'number');
-    if (!hasVisualViewport) {
-        return 1;
-    }
-    const viewportScale = window.visualViewport.scale;
-    if (viewportScale) {
-        return viewportScale;
-    }
-    return 1;
-}
 function cssWidthForTrue1920(baseWidth = 1920) {
-    const zoomFactor = getVisualZoom();
-    if (zoomFactor === 0) {
-        return baseWidth;
+    if (!baseWidth) {
+        return 1920;
     }
-    const calculatedCssWidth = Math.round(baseWidth / zoomFactor);
-    return calculatedCssWidth;
+    return baseWidth;
 }
 function buildIframe(targetCssWidth) {
     const iframeElement = document.createElement('iframe');


### PR DESCRIPTION
## Summary
- add a dedicated "Set zoom to 100%" control to the zoom warning modal alongside the dismiss action
- introduce logic to apply and clear a compensating CSS zoom ratio so the page renders at 100%
- reset the compensation when the browser zoom returns to the expected value

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690307d5cc1483259d900d4b53bb3d30